### PR TITLE
Import less Lodash

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 const { resolve } = require('path')
-const { merge } = require('lodash')
+const merge = require('lodash/merge')
 
 export default async function module (moduleOptions) {
   // Apply defaults

--- a/templates/auth.store.js
+++ b/templates/auth.store.js
@@ -1,6 +1,6 @@
 import Cookie from 'cookie'
 import Cookies from 'js-cookie'
-import { kebabCase } from 'lodash'
+import kebabCase from 'lodash/kebabCase'
 
 const options = <%= serialize(options) %>
 const storageTokenName = kebabCase(options.storageTokenName)


### PR DESCRIPTION
This module imports the entirety of Lodash which is very large. This results in large bundle sizes for anyone consuming this module. 

This PR imports only the merge function from Lodash.