### PR TITLE
Let LocalStorage to be optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Sets the global settings for store **logout** action.
 * **name** - Set the token name in the local storage.
 * **cookieName** - Set the token name in Cookies. (Set to `null` to disable)
 * **type** - Sets the token type of the authorization header.
+* **localStorage** - Decide whether to use or not the LocalStorage (default **true**).
 
 #### redirect
 * **notLoggedIn** - Sets the redirect URL default of the users not logged in. Only when `auth` middleware is added to a page.

--- a/lib/module.js
+++ b/lib/module.js
@@ -23,7 +23,8 @@ module.exports = function (moduleOptions) {
       enabled: true,
       name: 'token',
       cookieName: 'token',
-      type: 'Bearer'
+      type: 'Bearer',
+      localStorage: true
     }
   }
 

--- a/lib/templates/auth.store.js
+++ b/lib/templates/auth.store.js
@@ -42,13 +42,15 @@ export default {
       this.$axios.setToken(token, '<%= options.token.type %>');
 
       // Update localStorage
-      if (process.browser && localStorage) {
-        if (token) {
-          localStorage.setItem('<%= options.token.name %>', token)
-        } else {
-          localStorage.removeItem('<%= options.token.name %>')
+      <% if (options.token.localStorage) { %>
+        if (process.browser && localStorage) {
+          if (token) {
+            localStorage.setItem('<%= options.token.name %>', token)
+          } else {
+            localStorage.removeItem('<%= options.token.name %>')
+          }
         }
-      }
+      <% } %>
 
       <% if (options.token.cookieName) { %>
       // Update cookies
@@ -82,9 +84,11 @@ export default {
       let token
 
       // Try to extract token from localStorage
-      if (process.browser && localStorage) {
-        token = localStorage.getItem('<%= options.token.name %>')
-      }
+      <% if (options.token.localStorage) { %>
+        if (process.browser && localStorage) {
+          token = localStorage.getItem('<%= options.token.name %>')
+        }
+      <% } %>
 
       <% if (options.token.cookieName) { %>
       // Try to extract token from cookies


### PR DESCRIPTION
Not always we need to store the token as Cookie and LocalStorage at the same time