### PR TITLE
feature and fix: redirect on login & logout - excluding components from middleware..

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,10 @@ Sets the global settings for store **logout** action.
 * **cookieName** - Set the token name in Cookies.
 
 #### redirect
-* **guest** (Boolean) - Sets if the middleware should redirect guests users (non-authenticated).
-* **user** (Boolean) - Sets if the middleware should redirect logged users (authenticated).
-* **noAuth** (Boolean) - Sets if the middleware should redirect logged users (authenticated).
+* **guest** (Boolean) - Sets if the middleware should redirect guests users (unauthenticated). Only when `auth` middleware is added to a page.
+* **user** (Boolean) - Sets if the middleware should redirect logged users (authenticated). Only when `auth` middleware is added to a page.
 * **notLoggedIn** (Boolean)  - Sets the redirect URL default of the users not logged in. Only when `auth` middleware is added to a page.
-* **loggedIn** (Boolean) - Sets the redirect URL default of the users logged in. Only when `no-auth` middleware is added to a page.
+* **loggedIn** (Boolean) - Sets the redirect URL default of the users logged in. Only when `auth` middleware is added to a page.
 
 
 
@@ -124,6 +123,16 @@ router: {
   middleware: [
     'auth',
   ]
+}
+```
+
+### Middleware Components Exclusion
+You can set a `guarded` option to false in a specific component and the middleware will now ignore this component.
+```js
+export default {
+  options: {
+    guarded: false,
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@
       method: 'GET',
     },
     redirect: {
+      guest: true,
+      user: true,
       notLoggedIn: '/login',
       loggedIn: '/'
     },
@@ -81,8 +83,13 @@ Sets the global settings for store **logout** action.
 * **cookieName** - Set the token name in Cookies.
 
 #### redirect
+* **guest** (Boolean) - Sets if the middleware should redirect guests users (non-authenticated).
+* **user** (Boolean) - Sets if the middleware should redirect logged users (authenticated).
+* **noAuth** (Boolean) - Sets if the middleware should redirect logged users (authenticated).
 * **notLoggedIn** (Boolean)  - Sets the redirect URL default of the users not logged in. Only when `auth` middleware is added to a page.
 * **loggedIn** (Boolean) - Sets the redirect URL default of the users logged in. Only when `no-auth` middleware is added to a page.
+
+
 
 ## Example usage
 
@@ -115,8 +122,7 @@ store.getters['auth/loggedIn'] // get login status (true or false)
 // ... in nuxt.config.js ...
 router: {
   middleware: [
-    'auth', // If user not logged in, redirect to '/login' or to URL defined in redirect property
-    'no-auth' // If user is already logged in, redirect to '/' or to URL defined in redirect property
+    'auth',
   ]
 }
 ```

--- a/lib/module.js
+++ b/lib/module.js
@@ -19,6 +19,8 @@ module.exports = function (moduleOptions) {
       method: 'GET',
     },
     redirect: {
+      guest: true,
+      user: true,
       notLoggedIn: '/login',
       loggedIn: '/'
     },
@@ -29,7 +31,7 @@ module.exports = function (moduleOptions) {
       name: 'token',
       cookie: true,
       cookieName: 'token'
-    }
+    },
   }
 
   const options = merge(defaults, moduleOptions, this.options.auth)

--- a/lib/templates/auth.middleware.js
+++ b/lib/templates/auth.middleware.js
@@ -24,7 +24,7 @@ middleware.auth = function(context) {
       return r(guestRoute)
     }
 
-    if (<% options.redirect.user %> && s.getters['auth/loggedIn'] && authRoute !== p) {
+    if (<%= options.redirect.user %> && s.getters['auth/loggedIn'] && authRoute !== p) {
       return r(authRoute)
     }
   }

--- a/lib/templates/auth.middleware.js
+++ b/lib/templates/auth.middleware.js
@@ -1,29 +1,31 @@
 import middleware from './middleware'
 
-middleware.auth = function authMiddleware ({ route, redirect, store }) {
-  route.matched.some((currentRoute) => {
-    // Retriving Auth Guard status through route's component options.
-    const options = currentRoute.components.default.options
-    const guarded = options.guarded
+const isRouteGuarded = ({ route: { matched: m } }) =>
+  m.some(({ components: c }) => process.server
+    ? Object.values(c).some(({ _Ctor: _c }) =>
+      Object.values(_c).some(({ options: o }) => o && o.guarded)
+    )
+    : Object.values(c).some(o => o.options.guarded)
+  )
 
-    // Only apply the middleware to guarded routes
-    if (guarded) {
-      // Checking if guest redirection middleware is enabled
-    <% if (options.redirect.guest) { %>
-        // Guest is redirected back to login page
-        // and excluding redirected paths from hitting the middleware again.
-        if (!store.getters['auth/loggedIn'] && route.path !== '<%= options.redirect.notLoggedIn %>') {
-          return redirect('<%= options.redirect.notLoggedIn %>')
-        }
 
-        // Checking if user redirection middleware is enabled
-      <% } if (options.redirect.user) { %>
-        // Guest is redirected back to login page
-        // and excluding redirected paths from hitting the middleware again.
-        if (store.getters['auth/loggedIn'] && route.path !== '<%= options.redirect.loggedIn %>') {
-          return redirect('<%= options.redirect.loggedIn %>')
-        }
-      <% } %>
+middleware.auth = function(context) {
+  const { route: {path: p}, redirect: r, store: s } = context
+
+  // Registering guest and auth routes.
+  let guestRoute = '<%= options.redirect.notLoggedIn %>'
+  let authRoute = '<%= options.redirect.loggedIn %>'
+
+  // Retriving Auth Guard status through route's component options.
+  let g = isRouteGuarded(context)
+  // Apply the middleware to guarded routes
+  if (g) {
+    if (<%= options.redirect.guest %> && !s.getters['auth/loggedIn'] && guestRoute !== p) {
+      return r(guestRoute)
     }
-  });
+
+    if (<% options.redirect.user %> && s.getters['auth/loggedIn'] && authRoute !== p) {
+      return r(authRoute)
+    }
+  }
 }

--- a/lib/templates/auth.middleware.js
+++ b/lib/templates/auth.middleware.js
@@ -1,15 +1,28 @@
 import middleware from './middleware'
 
-middleware.auth = function authMiddleware ({ store, redirect }) {
-  // If user not logged in, redirect to /login
-  if (!store.getters['auth/loggedIn']) {
-    return redirect('<%= options.redirect.notLoggedIn %>')
-  }
-}
+middleware.auth = function authMiddleware ({ route, redirect, store }) {
+  route.matched.some((currentRoute) => {
+    // Retriving Auth Guard status through route's component options.
+    const options = currentRoute.components.default.options
+    const guarded = options.guarded
 
-middleware['no-auth'] = function noAuthMiddleware ({ store, redirect }) {
-  // If user is already logged in, redirect to /
-  if (store.getters['auth/loggedIn']) {
-    return redirect('<%= options.redirect.loggedIn %>')
-  }
+    // Only apply the middleware to guarded routes
+    // and exclude redirected paths to hit the middleware again.
+    if (guarded && route.path !== '<%= options.redirect.notLoggedIn %>') {
+      // Checking if guest redirection middleware is enabled
+    <% if (options.redirect.guest) { %>
+        // Guest is redirected back to login page.
+        if (!store.getters['auth/loggedIn']) {
+          return redirect('<%= options.redirect.notLoggedIn %>')
+        }
+
+        // Checking if user redirection middleware is enabled
+      <% } if (options.redirect.user) { %>
+        // Guest is redirected back to login page
+        if (store.getters['auth/loggedIn']) {
+          return redirect('<%= options.redirect.loggedIn %>')
+        }
+      <% } %>
+    }
+  });
 }

--- a/lib/templates/auth.middleware.js
+++ b/lib/templates/auth.middleware.js
@@ -7,19 +7,20 @@ middleware.auth = function authMiddleware ({ route, redirect, store }) {
     const guarded = options.guarded
 
     // Only apply the middleware to guarded routes
-    // and exclude redirected paths to hit the middleware again.
-    if (guarded && route.path !== '<%= options.redirect.notLoggedIn %>') {
+    if (guarded) {
       // Checking if guest redirection middleware is enabled
     <% if (options.redirect.guest) { %>
-        // Guest is redirected back to login page.
-        if (!store.getters['auth/loggedIn']) {
+        // Guest is redirected back to login page
+        // and excluding redirected paths from hitting the middleware again.
+        if (!store.getters['auth/loggedIn'] && route.path !== '<%= options.redirect.notLoggedIn %>') {
           return redirect('<%= options.redirect.notLoggedIn %>')
         }
 
         // Checking if user redirection middleware is enabled
       <% } if (options.redirect.user) { %>
         // Guest is redirected back to login page
-        if (store.getters['auth/loggedIn']) {
+        // and excluding redirected paths from hitting the middleware again.
+        if (store.getters['auth/loggedIn'] && route.path !== '<%= options.redirect.loggedIn %>') {
           return redirect('<%= options.redirect.loggedIn %>')
         }
       <% } %>

--- a/lib/templates/auth.plugin.js
+++ b/lib/templates/auth.plugin.js
@@ -14,4 +14,15 @@ export default async function (context, inject) {
 
   // Fetch initial state
   await context.store.dispatch('auth/fetch')
+
+  // Redirect on login and logout
+  context.store.watch(() => context.store.getters['auth/loggedIn'], newAuthState =>
+  {
+    if (newAuthState) {
+      context.app.router.replace('<%= options.redirect.loggedIn %>')
+      return
+    }
+
+    context.app.router.replace('<%= options.redirect.notLoggedIn %>')
+  })
 }


### PR DESCRIPTION
# Changes
- Automatically redirect on login and logout by watching `auth/loggedIn` getter, when this getter changes the plugins will automatically redirect to either login or logged pages.

See 91f808a for details.

- Reducing Middleware code redundancy by integrating `no-auth` middleware to `auth` middleware, disabling guest or logged users redirection is now done through `nuxt.config.js` options.

Module options :
```js
redirect: {
  // Set this if you want to redirect unauthenticated users to notLoggedIn
  guest: true,
  // Set this if you want to redirect authenticated users to loggedIn
  user: true,
  notLoggedIn: '/login',
  loggedIn: '/'
}
```
Middleware configuration :
```js
// ... in nuxt.config.js ...
router: {
  middleware: [
    'auth',
  ]
}
```
- (#42 inspired)  You can now exclude components from being guarded by the middleware by adding a `guarded` option to your component like this :
```js
export default {
  options: {
    // ... Set guarded to false and the middleware will now ignore this component or page
    guarded: false,
  }
}
```
- Prevent middleware infinite looping as seen in #39 by excluding loggedIn and notLoggedIn from hitting middleware on their respective scopes.