### PR TITLE
Allow `token` to be a nested object in the response

### DIFF
--- a/lib/templates/auth.store.js
+++ b/lib/templates/auth.store.js
@@ -146,7 +146,7 @@ export default {
       let data = await this.$axios.$post(endpoint, fields)
 
       <% if (options.token.enabled) { %>
-      await dispatch('updateToken', data['<%= options.token.name %>'])
+      await dispatch('updateToken', data.<%= options.token.name %>)
       <% } %>
 
       // Fetch authenticated user


### PR DESCRIPTION
With this change the `token` name can be `data.token` for example.

eg Response: 

```json
{
    "data": {
        ...
        "token": "..."
    }
}
```

I've not checked for BC, but in theory it should be fine.... right?