### PR TITLE
Fix token name

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
     },
     token: {
       enabled: true,
+      path: '.token',
       type: 'Bearer',
       localStorage: true,
       name: 'token',
@@ -80,8 +81,9 @@ Sets the global settings for store **logout** action.
 
 #### token
 * **enabled** (Boolean) - Get and use tokens for authentication.
+* **path** - Set the token path on json response.
 * **type** - Sets the token type of the authorization header.
-* **localStorage**(Boolean) - Keeps token in local storage, if enabled.
+* **localStorage** (Boolean) - Keeps token in local storage, if enabled.
 * **name** - Set the token name in the local storage.
 * **cookie** (Boolean) - Keeps token in cookies, if enabled.
 * **cookieName** - Set the token name in Cookies.

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -21,6 +21,7 @@ module.exports = {
   },
   token: {
     enabled: true,
+    path: '.token',
     type: 'Bearer',
     localStorage: true,
     name: 'token',

--- a/lib/templates/auth.store.js
+++ b/lib/templates/auth.store.js
@@ -153,7 +153,7 @@ export default {
       let data = await this.$axios.$post(endpoint, fields)
 
       <% if (options.token.enabled) { %>
-      await dispatch('updateToken', data.<%= options.token.name %>)
+      await dispatch('updateToken', data<%= options.token.path %>)
       <% } %>
 
       // Fetch authenticated user


### PR DESCRIPTION
On previous commit, the token option 'name' can set the token name in response.

But if the token it's on `data.primary.secondary.token` the name of token can't be the same value.

That's why, i want to add 'path' option to token option 👍 