### PR TITLE
fix: guard check in middleware

### DIFF
--- a/lib/templates/auth.middleware.js
+++ b/lib/templates/auth.middleware.js
@@ -7,7 +7,7 @@ middleware.auth = function ({ route, redirect, store }) {
   const authRoute = '<%= options.redirect.loggedIn %>'
 
   // Skip if route is not guarded
-  if (!isRouteGuarded(route)) {
+  if (isRouteGuarded(route)) {
     return
   }
 


### PR DESCRIPTION
While cleaning up the code and refactoring it a bit, it seems that a little mistake got in there:

```diff
-- if (!isRouteGuarded(route)) {
++ if (isRouteGuarded(route)) {
```
`isRouteGuarded` return the `guarded` option value, which is either:

- `undefined` - happens when the option `guarded` is not set into our components.
- `true` - happens when the option `guarded` is set to `true`
- `false` - happens when the option `guarded` is set to `true`

With the current line `if (!isRouteGuarded(route))` our middleware will not act as intended, if the `guarded` option is false, it will become `true` with the type inversion operator.

Should the `isRouteGuarded` be renamed for more clarity, or patch it as proposed in this PR?

