### PR TITLE
Clear axios token after logout

### DIFF
--- a/lib/auth/schemes/local.js
+++ b/lib/auth/schemes/local.js
@@ -19,6 +19,13 @@ export default class LocalScheme {
     }
   }
 
+  _clearToken () {
+    if (this.options.globalToken) {
+      // Clear Authorization token for all axios requests
+      this.auth.ctx.app.$axios.setToken(false)
+    }
+  }
+
   mounted () {
     if (this.options.tokenRequired) {
       const token = this.auth.syncToken(this.name)
@@ -79,6 +86,10 @@ export default class LocalScheme {
     await this.auth
       .requestWith(this.name, endpoint, this.options.endpoints.logout)
       .catch(() => { })
+
+    if (this.options.tokenRequired) {
+      this._clearToken()
+    }
 
     return this.auth.reset()
   }

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -39,18 +39,55 @@ describe('auth', () => {
     await page.goto(url('/'))
     await page.waitForFunction('!!window.$nuxt')
 
-    const { token, user } = await page.evaluate(async () => {
+    const { token, user, axiosBearer } = await page.evaluate(async () => {
       await window.$nuxt.$auth.loginWith('local', {
         data: { username: 'test_username', password: '123' }
       })
 
       return {
+        axiosBearer: window.$nuxt.$axios.defaults.headers.common.Authorization,
         token: window.$nuxt.$auth.getToken(),
         user: window.$nuxt.$auth.state.user
       }
     })
 
+    expect(axiosBearer).toBeDefined()
     expect(token).toBeDefined()
     expect(user.username).toBe('test_username')
+  })
+
+  test('logout', async () => {
+    const page = await browser.newPage()
+    await page.goto(url('/'))
+    await page.waitForFunction('!!window.$nuxt')
+
+    const { loginAxiosBearer, loginToken } = await page.evaluate(async () => {
+      await window.$nuxt.$auth.loginWith('local', {
+        data: { username: 'test_username', password: '123' }
+      })
+
+      return {
+        loginAxiosBearer: window.$nuxt.$axios.defaults.headers.common.Authorization,
+        loginToken: window.$nuxt.$auth.getToken()
+      }
+    })
+
+    expect(loginAxiosBearer).toBeDefined()
+    expect(loginToken).toBeDefined()
+
+    const { logoutToken, logoutAxiosBearer } = await page.evaluate(async () => {
+      await window.$nuxt.$auth.logout()
+
+      // eslint-disable-next-line no-console
+      console.log('nuxt: ' + window.$nuxt)
+
+      return {
+        logoutAxiosBearer: window.$nuxt.$axios.defaults.headers.common.Authorization,
+        logoutToken: window.$nuxt.$auth.getToken()
+      }
+    })
+
+    expect(logoutToken).toBeNull()
+    expect(logoutAxiosBearer).toBeUndefined()
   })
 })


### PR DESCRIPTION
References #57 

After a logout the axios token should be cleared so subsequent api requests do not use the logged out user's credentials.