### PR TITLE
Add full path redirect option

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -66,6 +66,12 @@ If enabled, user will be automatically logged out if any error happens. (For exa
 
 If enabled, user will redirect back to the original guarded route instead of `redirect.home`.
 
+### `fullPathRedirect`
+
+Default: `false`
+
+If true, use the full route path with query parameters for redirect
+
 ### `vuex.namespace`
 
 * Default: `auth`

--- a/lib/auth/auth.js
+++ b/lib/auth/auth.js
@@ -435,7 +435,7 @@ export default class Auth {
       return
     }
 
-    const from = this.ctx.route.path
+    const from = this.options.fullPathRedirect ? this.ctx.route.path : this.ctx.route.fullPath
 
     let to = this.options.redirect[name]
     if (!to) {

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -13,6 +13,8 @@ module.exports = {
 
   rewriteRedirects: true,
 
+  fullPathRedirect: false,
+
   redirect: {
     login: '/login',
     logout: '/',


### PR DESCRIPTION
Currently, only `this.$route.path` is used for redirecting back after login. I've added an option so `this.$route.fullPath` can be used as well.

PS: @pi0 Any chance to see a release for that feature on master (if I PR it there) soon?