### PR TITLE
fix(local-scheme-token): avoid token type duplicata on Axios requests

### DIFF
--- a/lib/schemes/local.js
+++ b/lib/schemes/local.js
@@ -9,7 +9,7 @@ export default class LocalScheme {
   _setToken (token) {
     if (this.options.globalToken) {
       // Set Authorization token for all axios requests
-      this.$auth.ctx.app.$axios.setToken(token, this.options.tokenType)
+      this.$auth.ctx.app.$axios.setToken(token)
     }
   }
 

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -53,6 +53,8 @@ describe('auth', () => {
     })
 
     expect(axiosBearer).toBeDefined()
+    expect(axiosBearer.split(' ')).toHaveLength(2)
+    expect(axiosBearer.split(' ')[0]).toMatch(/^Bearer$/i)
     expect(token).toBeDefined()
     expect(user).toBeDefined()
     expect(user.username).toBe('test_username')


### PR DESCRIPTION
This is a fix for #113 and related tests with local test to avoid regression 🎊 