### PR TITLE
Added support for logging out without an API endpoint

### DIFF
--- a/lib/schemes/local.js
+++ b/lib/schemes/local.js
@@ -73,14 +73,14 @@ export default class LocalScheme {
   }
 
   async logout (endpoint) {
-    if (!this.options.endpoints.logout) {
-      return
+    // Only connect to logout endpoint if it's configured
+    if (this.options.endpoints.logout) {
+      await this.$auth
+        .requestWith(this.name, endpoint, this.options.endpoints.logout)
+        .catch(() => { })
     }
 
-    await this.$auth
-      .requestWith(this.name, endpoint, this.options.endpoints.logout)
-      .catch(() => { })
-
+    // But logout locally regardless
     if (this.options.tokenRequired) {
       this._clearToken()
     }


### PR DESCRIPTION
This is a fix for
https://nuxtjs.cmty.io/nuxt-community/auth-module/issues/c90

Setting the `logout` strategy to `false` will effectively mean that
logout does nothing (it simple returns).

However, when you have a stateless API, and no need to call
a logout endpoint, you still want the user to be logged out
in the browser (token removed, session reset, that sort of stuff).

This change handles that by not returning if the logout option
is falsy, but instead only skipping over the networking part.

I think this is the behaviour people would expect when they set
logout to `false`.