### PR TITLE
Let 404s surface when auth middleware applied globally.

### DIFF
--- a/lib/core/middleware.js
+++ b/lib/core/middleware.js
@@ -1,9 +1,16 @@
 import Middleware from '../middleware'
-import { routeOption } from './utilities'
+import { routeOption, getMatchedComponents } from './utilities'
 
 Middleware.auth = function (ctx) {
   // Disable middleware if options: { auth: false } is set on the route
   if (routeOption(ctx.route, 'auth', false)) {
+    return
+  }
+
+  // Disable middleware if no route was matched to allow 404/error page
+  const matches = []
+  const Components = getMatchedComponents(ctx.route, matches)
+  if (!Components.length) {
     return
   }
 

--- a/lib/core/utilities.js
+++ b/lib/core/utilities.js
@@ -44,3 +44,12 @@ export const routeOption = (route, key, value) => {
     }
   })
 }
+
+export const getMatchedComponents = (route, matches = false) => {
+  return [].concat.apply([], route.matched.map(function (m, index) {
+    return Object.keys(m.components).map(function (key) {
+      matches && matches.push(index)
+      return m.components[key]
+    })
+  }))
+}


### PR DESCRIPTION
As logged in issue https://github.com/nuxt-community/auth-module/issues/126, when the `auth` middleware is applied globally, non-authenticated users who hit non-existant routes (e.g. /asdf/asdf) get redirected to the login page. IMO, these should flow through to the 404 error page.

Notes:
* Borrowed the getMatchedComponents method from the Nuxt core utils.
* I hope I'm not opening up any potential security hole here?! Sanity check would be awesome