### PR TITLE
Feature idea: Allow custom "login required" handling

### DIFF
--- a/lib/core/middleware.js
+++ b/lib/core/middleware.js
@@ -12,9 +12,13 @@ Middleware.auth = function (ctx) {
   if (ctx.app.$auth.$state.loggedIn) {
     // -- Authorized --
     // Redirect to home page if inside login page
-    if (login && ctx.route.path === login.split('?')[0]) {
+    if (login && typeof login === String && ctx.route.path === login.split('?')[0]) {
       ctx.app.$auth.redirect('home')
     }
+  } else if (login && typeof login === function) {
+    // -- Guest --
+    // Call configured function to handle guest accessing a page requiring authentication
+    login(ctx)
   } else {
     // -- Guest --
     // Redirect to login path if not authorized

--- a/lib/core/middleware.js
+++ b/lib/core/middleware.js
@@ -12,10 +12,10 @@ Middleware.auth = function (ctx) {
   if (ctx.app.$auth.$state.loggedIn) {
     // -- Authorized --
     // Redirect to home page if inside login page
-    if (login && typeof login === String && ctx.route.path === login.split('?')[0]) {
+    if (login && typeof login === "string" && ctx.route.path === login.split('?')[0]) {
       ctx.app.$auth.redirect('home')
     }
-  } else if (login && typeof login === function) {
+  } else if (login && typeof login === "function") {
     // -- Guest --
     // Call configured function to handle guest accessing a page requiring authentication
     login(ctx)


### PR DESCRIPTION
My scenario is that I'm using Auth0, so I'm trying to avoid showing a /login screen that just then sends them off to Auth0, it's too jarring.

What I'm doing on my nav login button is simply `$auth.login()`, and I think if a user hits a page requiring auth and aren't, it'd be nice to be able to configure the middleware to do the same, like so:
```javascript
// nuxt.config.js
auth: {
  redirect: {
    login: (ctx) => { 
      if (process.browser) { 
        ctx.app.$auth.login()
      }
      else {
        // SSR: Not sure what to do here, I guess it has to get the login page
      }
    }
  }
}
```

I can think of other scenarios where this could be useful, e.g. if a developer needed to put some things in session, send them to login and then when they come back logged in be able to finish processing whatever needed to be done with that session data.

## Other ways ##

### Navigation guards ###
Could use nuxt.config.js `route { extendRoutes: (routes) => { ...; }` to add/modify a route for login page (ctx.app.$auth.options.redirect.login) and on it a "per-route" guard inside of which I simply do: `ctx.app.$auth.login(); next(false);`

### Middleware ###
This works, so potentially this PR is pointless!

```javascript
export default function (context) {
  // TODO: Make this check handle query and hash too
  if (context.route.path === context.app.$auth.options.redirect.login) {
    if (process.browser) {
      context.app.$auth.login() // go straight to Auth0 login
      context.next(false) // prevent continuation
    } else {
      // SSR: not sure what to do here, I guess it has to get the login page
    }
  }
}
```

Thanks!