### PR TITLE
Don't redirect callback to login when using 'auth' globally

### DIFF
--- a/lib/core/middleware.js
+++ b/lib/core/middleware.js
@@ -7,17 +7,21 @@ Middleware.auth = function (ctx) {
     return
   }
 
-  const { login } = ctx.app.$auth.options.redirect
-
+  const { login, callback } = ctx.app.$auth.options.redirect
+  
   if (ctx.app.$auth.$state.loggedIn) {
     // -- Authorized --
-    // Redirect to home page if inside login page
-    if (login && ctx.route.path === login.split('?')[0]) {
+    // Redirect to home page if inside login page (or login page disabled)
+    if (!login || ctx.route.path === login.split('?')[0]) {
       ctx.app.$auth.redirect('home')
     }
   } else {
     // -- Guest --
-    // Redirect to login path if not authorized
-    ctx.app.$auth.redirect('login')
+    // Redirect to login page if not authorized and not inside callback page
+    // (Those passing `callback` at runtime need to mark their callback component
+    // with `auth: false` to avoid an unnecessary redirect from callback to login)
+    if (!callback || ctx.route.path !== callback.split('?')[0]) {
+      ctx.app.$auth.redirect('login')
+    }
   }
 }


### PR DESCRIPTION
Also, if dev has disabled redirect (all or callback/login), supported according to the [options](https://auth.nuxtjs.org/options.html#redirect) documentation, don't let that affect the middleware here.