### PR TITLE
Added support for Apollo

### DIFF
--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -1,5 +1,5 @@
 import getProp from 'dotprop'
-
+import _ from 'lodash'
 import Storage from './storage'
 import { routeOption, isRelativeURL, isSet, isSameURL } from './utilities'
 
@@ -210,17 +210,12 @@ export default class Auth {
     return this.$storage.getState('busy')
   }
 
-  request (endpoint, defaults) {
-    const _endpoint =
-      typeof defaults === 'object'
-        ? Object.assign({}, defaults, endpoint)
-        : endpoint
-
+  requestAxios (endpoint) {
     return this.ctx.app.$axios
-      .request(_endpoint)
+      .request(endpoint)
       .then(response => {
-        if (_endpoint.propertyName) {
-          return getProp(response.data, _endpoint.propertyName)
+        if (endpoint.propertyName) {
+          return getProp(response.data, endpoint.propertyName)
         } else {
           return response.data
         }
@@ -232,6 +227,41 @@ export default class Auth {
         // Throw error
         return Promise.reject(error)
       })
+  }
+
+  requestApollo (operation) {
+    const isQuery = operation.hasOwnProperty('query')
+    const opFn = this.ctx.app.apolloProvider.defaultClient[
+      isQuery ? 'query' : 'mutate'
+    ]
+    const res = opFn(operation)
+      .then(response => {
+        if (operation.propertyName) {
+          const propVal = getProp(response.data, operation.propertyName)
+          return propVal
+        } else {
+          return response.data
+        }
+      })
+      .catch(error => {
+        // Call all error handlers
+        this.callOnError(error, { method: 'request' })
+
+        // Throw error
+        return Promise.reject(error)
+      })
+    return res
+  }
+
+  request (endpoint, defaults) {
+    const et = _.merge({}, defaults, endpoint)
+    const _endpoint = typeof defaults === 'object' ? et : endpoint
+
+    if (this.strategy.options.useApollo) {
+      return this.requestApollo(_endpoint)
+    } else {
+      return this.requestAxios(_endpoint)
+    }
   }
 
   requestWith (strategy, endpoint, defaults) {

--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -1,5 +1,5 @@
 import getProp from 'dotprop'
-import _ from 'lodash'
+import merge from 'lodash'
 import Storage from './storage'
 import { routeOption, isRelativeURL, isSet, isSameURL } from './utilities'
 
@@ -229,16 +229,15 @@ export default class Auth {
       })
   }
 
-  requestApollo (operation) {
-    const isQuery = operation.hasOwnProperty('query')
-    const opFn = this.ctx.app.apolloProvider.defaultClient[
+  requestApollo (operationArgs) {
+    const isQuery = operationArgs.hasOwnProperty('query')
+    const operation = this.ctx.app.apolloProvider.defaultClient[
       isQuery ? 'query' : 'mutate'
     ]
-    const res = opFn(operation)
+    return operation(operationArgs)
       .then(response => {
-        if (operation.propertyName) {
-          const propVal = getProp(response.data, operation.propertyName)
-          return propVal
+        if (operationArgs.propertyName) {
+          return getProp(response.data, operationArgs.propertyName)
         } else {
           return response.data
         }
@@ -250,12 +249,10 @@ export default class Auth {
         // Throw error
         return Promise.reject(error)
       })
-    return res
   }
 
   request (endpoint, defaults) {
-    const et = _.merge({}, defaults, endpoint)
-    const _endpoint = typeof defaults === 'object' ? et : endpoint
+    const _endpoint = typeof defaults === 'object' ? merge({}, defaults, endpoint) : endpoint
 
     if (this.strategy.options.useApollo) {
       return this.requestApollo(_endpoint)


### PR DESCRIPTION
Sample scheme file and nuxt.config are found here :  https://gist.github.com/JRobber/bfbd555d070868e6e80840cdc3d62759

Notable changes : 

* Uses operations instead of endpoints keyword
* must set `useApollo` property to true on the strategy level

If you like the direction I can add to the documentation.  
We could also consider adding the apollo scheme into the default schemes that come with.