### PR TITLE
fix fullPathRedirect

### DIFF
--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -304,7 +304,7 @@ export default class Auth {
       return
     }
 
-    const from = this.options.fullPathRedirect ? this.ctx.route.path : this.ctx.route.fullPath
+    const from = this.options.fullPathRedirect ? this.ctx.route.fullPath : this.ctx.route.path
 
     let to = this.options.redirect[name]
     if (!to) {
@@ -313,7 +313,7 @@ export default class Auth {
 
     // Apply rewrites
     if (this.options.rewriteRedirects) {
-      if (name === 'login' && isRelativeURL(from) && !isSameURL(to, from)) {
+      if (name === 'login' && isRelativeURL(from.split('?')[0]) && !isSameURL(to, from)) {
         this.$storage.setUniversal('redirect', from)
       }
 


### PR DESCRIPTION
`route.fullPath` is the full resolved URL including query and hash, `route. path` always resolved as an absolute path

`isRelativeURL` not work for path with query, so `from.split('?')[0]` only pass the path to `isRelativeURL`

