### PR TITLE
Logout locally before logging in

### DIFF
--- a/lib/schemes/local.js
+++ b/lib/schemes/local.js
@@ -34,6 +34,9 @@ export default class LocalScheme {
       return
     }
 
+    // Ditch any leftover local tokens before attempting to log in
+    await this._logoutLocally()
+
     const result = await this.$auth.request(
       endpoint,
       this.options.endpoints.login
@@ -81,6 +84,10 @@ export default class LocalScheme {
     }
 
     // But logout locally regardless
+    return this._logoutLocally()
+  }
+
+  async _logoutLocally () {
     if (this.options.tokenRequired) {
       this._clearToken()
     }


### PR DESCRIPTION
This is a fix for issue #136. When using the local authentication strategy, we need to "logout locally" before attempting to log in, so we're not sending (e.g.) an expired token along with the login request.

This moves the local functionality out of the `logout()` method and calls it from both `login` and `logout`.