### PR TITLE
Add support for custom token key in request header

### DIFF
--- a/lib/schemes/local.js
+++ b/lib/schemes/local.js
@@ -9,14 +9,14 @@ export default class LocalScheme {
   _setToken (token) {
     if (this.options.globalToken) {
       // Set Authorization token for all axios requests
-      this.$auth.ctx.app.$axios.setToken(token)
+      this.$auth.ctx.app.$axios.setHeader(this.options.tokenName, token)
     }
   }
 
   _clearToken () {
     if (this.options.globalToken) {
       // Clear Authorization token for all axios requests
-      this.$auth.ctx.app.$axios.setToken(false)
+      this.$auth.ctx.app.$axios.setHeader(this.options.tokenName, false)
     }
   }
 
@@ -92,5 +92,6 @@ export default class LocalScheme {
 const DEFAULTS = {
   tokenRequired: true,
   tokenType: 'Bearer',
-  globalToken: true
+  globalToken: true,
+  tokenName: 'Authorization'
 }


### PR DESCRIPTION
Sometimes we need to change token key name in requests header, in order to support custom token name we could define new option in local strategy. lets call it `tokenName`

```
    auth: {
        strategies: {
            local: {
                tokenName: 'x-auth',
                endpoints: ...
            }
        }
    }
```