### PR TITLE
fix: Storage cookie get on client side

### DIFF
--- a/lib/core/storage.js
+++ b/lib/core/storage.js
@@ -183,7 +183,7 @@ export default class Storage {
   }
 
   getCookie (key, isJson) {
-    if (!this.options.cookie || !this.ctx.req) {
+    if (!this.options.cookie || (process.server && !this.ctx.req)) {
       return
     }
 


### PR DESCRIPTION
The `ctx.req` only exist on server side (https://nuxtjs.org/api/context/), this function will never be executed on client side.

By the way : thanks for this module :+1: 