### PR TITLE
Fix: no more redirect on direct load / refresh of a page.

### DIFF
--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -27,6 +27,11 @@ export default class Auth {
     if (process.browser) {
       this.$storage.watchState('loggedIn', loggedIn => {
         if (!routeOption(this.ctx.route, 'auth', false)) {
+          //disable redirect on refresh / direct load of a page.
+          if(loggedIn && !this.ctx.from) {
+             return
+          }
+
           this.redirect(loggedIn ? 'home' : 'logout')
         }
       })


### PR DESCRIPTION
If you load a page with auth directly from the URL bar (or refresh the page) you will allways be redirected to `home`. This is simply because the user gets re-logged in, and the watcher will trigger the `loggedIn` redirect.

Now, as soon as we move to another page, `this.ctx.from` is being added so we know the previous page.
This means that on the initial load, ctx.from is not avaible.

Because of that, a check in the `watchState` to see if `ctx.from` excists should disable the redirect only on first direct load of a page.