### PR TITLE
Fix Github provider

### DIFF
--- a/docs/providers/github.md
+++ b/docs/providers/github.md
@@ -8,7 +8,8 @@
 auth: {
   strategies: {
       github: {
-        client_id: '...'
+        client_id: '...',
+        client_secret: '...'
       },
   }
 }
@@ -22,7 +23,7 @@ this.$auth.loginWith('github')
 
 💁 This provider is based on [oauth2 scheme](../schemes/oauth2.md) and supports all scheme options.
 
-### Obtaining `client_id`
+### Obtaining `client_id` and `client_secret`
 
-This option is **REQUIRED**. To obtain one, create your app in [Create a new Oauth APP](https://github.com/settings/applications/new) and use provided "Client ID".
+This option is **REQUIRED**. To obtain one, create your app in [Create a new Oauth APP](https://github.com/settings/applications/new) and use provided "Client ID" and "Client Secret".
 

--- a/lib/providers/_utils.js
+++ b/lib/providers/_utils.js
@@ -21,8 +21,8 @@ function addAuthorize (strategy) {
   // Set response_type to code
   strategy.response_type = 'code'
 
-  // Json parser
-  const jsonMiddleware = bodyParser.json()
+  // Form data parser
+  const formMiddleware = bodyParser.urlencoded()
 
   // Register endpoint
   this.options.serverMiddleware.unshift({
@@ -32,7 +32,7 @@ function addAuthorize (strategy) {
         return next()
       }
 
-      jsonMiddleware(req, res, () => {
+      formMiddleware(req, res, () => {
         const { code } = req.body
 
         if (!code) {


### PR DESCRIPTION
Fix issue with using `jsonMiddleware` for form encoded data. Update documentation to indicate that `client_secret` is required.