### PR TITLE
Fix typo in Laravel Passport docs

### DIFF
--- a/docs/providers/passport.md
+++ b/docs/providers/passport.md
@@ -1,6 +1,6 @@
 # Laravel Passport
 
-[Source Code](https://github.com/nuxt-community/auth-module/blob/dev/lib/providers/passport.js)
+[Source Code](https://github.com/nuxt-community/auth-module/blob/dev/lib/providers/laravel.passport.js)
 
 ## Usage
 

--- a/docs/providers/passport.md
+++ b/docs/providers/passport.md
@@ -21,7 +21,7 @@ auth: {
 Anywhere in your application logic:
 
 ```js
-this.$auth.loginWith('passport')
+this.$auth.loginWith('laravel.passport')
 ```
 
 💁 This provider is based on [oauth2 scheme](../schemes/oauth2.md) and supports all scheme options.


### PR DESCRIPTION
Didn't completely update the docs to reflect name change to from `passport` to `laravel.passport`.