### PR TITLE
Add redirect_uri, response_type and grant_type to server-side authentication request

### DIFF
--- a/lib/providers/_utils.js
+++ b/lib/providers/_utils.js
@@ -33,7 +33,12 @@ function addAuthorize (strategy) {
       }
 
       formMiddleware(req, res, () => {
-        const { code } = req.body
+        const {
+          code,
+          redirect_uri: redirectUri = strategy.redirect_uri,
+          response_type: responseType = strategy.response_type,
+          grant_type: grantType = strategy.grant_type
+        } = req.body
 
         if (!code) {
           return next()
@@ -46,6 +51,9 @@ function addAuthorize (strategy) {
             data: {
               client_id: clientID,
               client_secret: clientSecret,
+              grant_type: grantType,
+              response_type: responseType,
+              redirect_uri: redirectUri,
               code
             },
             headers: {

--- a/lib/providers/laravel.passport.js
+++ b/lib/providers/laravel.passport.js
@@ -1,6 +1,4 @@
-const axios = require('axios')
-const bodyParser = require('body-parser')
-const { assignDefaults } = require('./_utils')
+const { assignDefaults, addAuthorize } = require('./_utils')
 
 module.exports = function laravelPassport (strategy) {
   assignDefaults(strategy, {
@@ -15,65 +13,5 @@ module.exports = function laravelPassport (strategy) {
     scope: '*'
   })
 
-  // Get client_secret, client_id and token_endpoint
-  const clientSecret = strategy.client_secret
-  const clientID = strategy.client_id
-  const tokenEndpoint = strategy.token_endpoint
-
-  // IMPORTANT: remove client_secret from generated bundle
-  delete strategy.client_secret
-
-  // Endpoint
-  const endpoint = `/_auth/oauth/${strategy._name}/authorize`
-  strategy.access_token_endpoint = endpoint
-
-  // Set response_type to code
-  strategy.response_type = 'code'
-
-  // Form parser
-  const formMiddleware = bodyParser.urlencoded()
-
-  // Register endpoint
-  this.options.serverMiddleware.unshift({
-    path: endpoint,
-    handler: (req, res, next) => {
-      if (req.method !== 'POST') {
-        return next()
-      }
-
-      formMiddleware(req, res, () => {
-        const {
-          code,
-          redirect_uri: redirectUri = strategy.redirect_uri,
-          response_type: responseType = strategy.response_type,
-          grant_type: grantType = strategy.grant_type
-        } = req.body
-
-        if (!code) {
-          return next()
-        }
-
-        axios
-          .request({
-            method: 'post',
-            url: tokenEndpoint,
-            data: {
-              client_id: clientID,
-              client_secret: clientSecret,
-              grant_type: grantType,
-              response_type: responseType,
-              redirect_uri: redirectUri,
-              code
-            },
-            headers: {
-              Accept: 'application/json'
-            }
-          })
-          .then(response => {
-            res.end(JSON.stringify(response.data))
-          })
-          .catch(error => next(error))
-      })
-    }
-  })
+  addAuthorize.call(this, strategy)
 }


### PR DESCRIPTION
The oauth scheme [sends `code`, `client_id`, `redirect_uri`, `response_type` and `grant_type`](https://github.com/nuxt-community/auth-module/blob/dev/lib/schemes/oauth2.js#L103-L109) to the authentication provider. When using the Github provider, a [`serverMiddleware` is added](https://github.com/nuxt-community/auth-module/blob/dev/lib/providers/_utils.js#L28-L61) to attach the `client_secret` and proxy the request on through to Github.

Currently, the server middleware only passes the `client_id`, `client_secret` and `code` no matter what is sent to it. This pull request would ensure that the `redirect_uri`, `response_type` and `grant_type` are also included.

Additionally, this change will allow the laravel.passport provider to re-use the `addAuthorize` method.