### PR TITLE
Fix an exception when running the auth plugin in spa mode

### DIFF
--- a/lib/core/utilities.js
+++ b/lib/core/utilities.js
@@ -32,7 +32,7 @@ export const routeOption = (route, key, value) => {
     if (process.browser) {
       // Browser
       return Object.values(m.components).some(
-        component => component.options[key] === value
+        component => component.options && component.options[key] === value
       )
     } else {
       // SSR


### PR DESCRIPTION
When running nuxt in "spa" mode sometimes returns the exception "client.js:49 TypeError: Cannot read property 'auth' of undefined", seems like a strict mode error,

The full error:

client.js:49 TypeError: Cannot read property 'auth' of undefined
    at utilities.js:35
    at Array.some (<anonymous>)
    at utilities.js:34
    at Array.some (<anonymous>)
    at routeOption (utilities.js:31)
    at Vue.<anonymous> (auth.js:29)
    at Watcher.run (vue.runtime.esm.js:3229)
    at flushSchedulerQueue (vue.runtime.esm.js:2977)
    at Array.<anonymous> (vue.runtime.esm.js:1833)
    at flushCallbacks (vue.runtime.esm.js:1754)