### PR TITLE
Ability to impersonate another user once logged in as admin

### DIFF
--- a/docs/providers/passport.md
+++ b/docs/providers/passport.md
@@ -1,6 +1,6 @@
 # Laravel Passport
 
-[Source Code](https://github.com/nuxt-community/auth-module/blob/dev/lib/providers/passport.js)
+[Source Code](https://github.com/nuxt-community/auth-module/blob/dev/lib/providers/laravel.passport.js)
 
 ## Usage
 
@@ -21,7 +21,7 @@ auth: {
 Anywhere in your application logic:
 
 ```js
-this.$auth.loginWith('passport')
+this.$auth.loginWith('laravel.passport')
 ```
 
 💁 This provider is based on [oauth2 scheme](../schemes/oauth2.md) and supports all scheme options.

--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -150,9 +150,9 @@ export default class Auth {
 
   reset () {
     if (!this.strategy.reset) {
-      this.setUser(null)
-      this.setToken(this.$state.strategy, null)
-      this.setRefreshToken(this.$state.strategy, null)
+      this.setUser(false)
+      this.setToken(this.$state.strategy, false)
+      this.setRefreshToken(this.$state.strategy, false)
       return Promise.resolve()
     }
 
@@ -270,8 +270,7 @@ export default class Auth {
     if (!_endpoint.headers) {
       _endpoint.headers = {}
     }
-
-    if (!_endpoint.headers['Authorization'] && isSet(token)) {
+    if (!_endpoint.headers['Authorization'] && isSet(token) && token) {
       _endpoint.headers['Authorization'] = token
     }
 

--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -152,6 +152,7 @@ export default class Auth {
     if (!this.strategy.reset) {
       this.setUser(false)
       this.setToken(this.$state.strategy, false)
+      this.setToken(this.$state.strategy + '.impersonate', false)
       this.setRefreshToken(this.$state.strategy, false)
       return Promise.resolve()
     }

--- a/lib/core/storage.js
+++ b/lib/core/storage.js
@@ -156,6 +156,9 @@ export default class Storage {
     const _key = this.options.localStorage.prefix + key
 
     const value = localStorage.getItem(_key)
+    if (value === 'false') {
+      return false
+    }
 
     return isJson ? JSON.parse(value) : value
   }
@@ -195,7 +198,9 @@ export default class Storage {
 
     const cookies = parseCookie(cookieStr || '') || {}
     const value = cookies[_key]
-
+    if (value === 'false') {
+      return false
+    }
     return isJson ? JSON.parse(value) : value
   }
 }

--- a/lib/core/utilities.js
+++ b/lib/core/utilities.js
@@ -32,7 +32,7 @@ export const routeOption = (route, key, value) => {
     if (process.browser) {
       // Browser
       return Object.values(m.components).some(
-        component => component.options[key] === value
+        component => component.options && component.options[key] === value
       )
     } else {
       // SSR

--- a/lib/providers/_utils.js
+++ b/lib/providers/_utils.js
@@ -33,7 +33,12 @@ function addAuthorize (strategy) {
       }
 
       formMiddleware(req, res, () => {
-        const { code } = req.body
+        const {
+          code,
+          redirect_uri: redirectUri = strategy.redirect_uri,
+          response_type: responseType = strategy.response_type,
+          grant_type: grantType = strategy.grant_type
+        } = req.body
 
         if (!code) {
           return next()
@@ -46,6 +51,9 @@ function addAuthorize (strategy) {
             data: {
               client_id: clientID,
               client_secret: clientSecret,
+              grant_type: grantType,
+              response_type: responseType,
+              redirect_uri: redirectUri,
               code
             },
             headers: {

--- a/lib/providers/laravel.passport.js
+++ b/lib/providers/laravel.passport.js
@@ -1,6 +1,4 @@
-const axios = require('axios')
-const bodyParser = require('body-parser')
-const { assignDefaults } = require('./_utils')
+const { assignDefaults, addAuthorize } = require('./_utils')
 
 module.exports = function laravelPassport (strategy) {
   assignDefaults(strategy, {
@@ -15,65 +13,5 @@ module.exports = function laravelPassport (strategy) {
     scope: '*'
   })
 
-  // Get client_secret, client_id and token_endpoint
-  const clientSecret = strategy.client_secret
-  const clientID = strategy.client_id
-  const tokenEndpoint = strategy.token_endpoint
-
-  // IMPORTANT: remove client_secret from generated bundle
-  delete strategy.client_secret
-
-  // Endpoint
-  const endpoint = `/_auth/oauth/${strategy._name}/authorize`
-  strategy.access_token_endpoint = endpoint
-
-  // Set response_type to code
-  strategy.response_type = 'code'
-
-  // Form parser
-  const formMiddleware = bodyParser.urlencoded()
-
-  // Register endpoint
-  this.options.serverMiddleware.unshift({
-    path: endpoint,
-    handler: (req, res, next) => {
-      if (req.method !== 'POST') {
-        return next()
-      }
-
-      formMiddleware(req, res, () => {
-        const {
-          code,
-          redirect_uri: redirectUri = strategy.redirect_uri,
-          response_type: responseType = strategy.response_type,
-          grant_type: grantType = strategy.grant_type
-        } = req.body
-
-        if (!code) {
-          return next()
-        }
-
-        axios
-          .request({
-            method: 'post',
-            url: tokenEndpoint,
-            data: {
-              client_id: clientID,
-              client_secret: clientSecret,
-              grant_type: grantType,
-              response_type: responseType,
-              redirect_uri: redirectUri,
-              code
-            },
-            headers: {
-              Accept: 'application/json'
-            }
-          })
-          .then(response => {
-            res.end(JSON.stringify(response.data))
-          })
-          .catch(error => next(error))
-      })
-    }
-  })
+  addAuthorize.call(this, strategy)
 }

--- a/lib/schemes/local.js
+++ b/lib/schemes/local.js
@@ -34,8 +34,12 @@ export default class LocalScheme {
       return
     }
 
+    let impersonate = (endpoint.data && endpoint.data.impersonate)
+
     // Ditch any leftover local tokens before attempting to log in
-    await this._logoutLocally()
+    if(!impersonate) {
+      await this._logoutLocally()
+    }
 
     const result = await this.$auth.request(
       endpoint,
@@ -47,7 +51,9 @@ export default class LocalScheme {
         ? this.options.tokenType + ' ' + result
         : result
 
-      this.$auth.setToken(this.name, token)
+      // Change Token Name on Impersonate (only if impersonating user has 'admin' scope)
+      let _key = (impersonate && this.$auth.user.scope.indexOf('admin') > -1) ? this.name + '.impersonate' : this.name;
+      this.$auth.setToken(_key, token)
       this._setToken(token)
     }
 
@@ -61,8 +67,15 @@ export default class LocalScheme {
       return
     }
 
+    // Check If Impersonate Token Exists
+    let _key = this.name
+    let impersonateToken = this.$auth.getToken(_key + '.impersonate')
+    if(impersonateToken && impersonateToken.length > 0) {
+      _key = _key + '.impersonate'
+    }
+
     // Token is required but not available
-    if (this.options.tokenRequired && !this.$auth.getToken(this.name)) {
+    if (this.options.tokenRequired && !this.$auth.getToken(_key)) {
       return
     }
 


### PR DESCRIPTION
Vue-auth has a nice feature to impersonate another user if logged in as administrator. This would be very nice to have in @nuxjs/auth. This pull request is a quick first version of a solution.

Usage is simple for local strategy:
```    
  async impersonate_lib(username, route = '/') {
      return this.$auth
        .loginWith('local', {
          data: {
            username: username,
            impersonate: true
          }
        })
        .then(() => {
          this.$router.push(route)
        })
        .catch(e => {
          this.error = e + ''
        })
    },
```
Server-side my API checks the following items:
```
      let adminToken = req.cookies['auth._token.local'].split(' ')[1]
      let adminUser = jsonwebtoken.verify(adminToken, 'dummy')

      // Only allow Impersonation under the following conditions:
      if (
          !adminUser.impersonate &&                 // Current User is not Impersonated himself AND
          adminUser.scope.indexOf('admin') > -1 &&  // The Current User has Admin Scope AND
          user.scope.indexOf('admin') === -1        // The User to Impersonate has NOT the Admin Scope (admins always login directly)
      ) {
          valid = true
      }
    }
```
The user object has an attribute 'impersonate' which can be true or false to show the users status.

Still to add: a nice function to stop impersonation. Quick fix for now:
```
    async unimpersonate_lib(route = '/') {
      this.$auth.$storage.setUniversal('_token.local.impersonate', null)
      this.$auth.fetchUser()
      this.$router.push(route)
      return
    }
```

Any additional comments or ideas are more than welcome!
Kind regards,
Ralf