### PR TITLE
Add function to compute user obj from token

### DIFF
--- a/docs/schemes/local.md
+++ b/docs/schemes/local.md
@@ -19,6 +19,7 @@ auth: {
         logout: { url: '/api/auth/logout', method: 'post' },
         user: { url: '/api/auth/user', method: 'get', propertyName: 'user' }
       },
+      userinfo_decode: false
       // tokenRequired: true,
       // tokenType: 'bearer',
     }
@@ -31,6 +32,12 @@ auth: {
 Each endpoint is used to make requests using axios. They are basically extending Axios [Request Config](https://github.com/axios/axios#request-config).
 
 > **TIP:** To disable each endpoint, simply set it's value to `false`.
+
+### `userinfo_decode`
+
+If your oauth2 provider does not provide a userinfo_endpoint (ex. AWS Cognito), setting this property to `true` will prompt the module to decode the token using `jwt-decode`.
+
+Defaults to `false`.
 
 #### `propertyName`
 

--- a/docs/schemes/oauth2.md
+++ b/docs/schemes/oauth2.md
@@ -13,6 +13,7 @@ auth: {
       _scheme: 'oauth2'
       authorization_endpoint: 'https://accounts.google.com/o/oauth2/auth',
       userinfo_endpoint: 'https://www.googleapis.com/oauth2/v3/userinfo',
+      userinfo_decode: false,
       scope: ['openid', 'profile', 'email'],
       response_type: 'token',
       token_type: 'Bearer',
@@ -33,6 +34,12 @@ auth: {
 While not a part of oauth2 spec, almost all oauth2 providers expose this endpoint to get user profile.
 
 If a `false` value is set, we only do login without fetching user profile.
+
+### `userinfo_decode`
+
+If your oauth2 provider does not provide a userinfo_endpoint (ex. AWS Cognito), setting this property to `true` will prompt the module to decode the token using `jwt-decode`.
+
+Defaults to `false`.
 
 ### `scope`
 

--- a/lib/schemes/local.js
+++ b/lib/schemes/local.js
@@ -1,3 +1,5 @@
+import jwtDecode from 'jwt-decode'
+
 export default class LocalScheme {
   constructor (auth, options) {
     this.$auth = auth
@@ -55,6 +57,13 @@ export default class LocalScheme {
   }
 
   async fetchUser (endpoint) {
+    // Decode token
+    if (this.options.userinfo_decode) {
+      const user = jwtDecode(this.$auth.getToken(this.name))
+      this.$auth.setUser(user)
+      return
+    }
+
     // User endpoint is disabled.
     if (!this.options.endpoints.user) {
       this.$auth.setUser({})

--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -1,3 +1,4 @@
+import jwtDecode from 'jwt-decode'
 import { encodeQuery, parseQuery, randomString } from '../utilities'
 
 const DEFAULTS = {
@@ -82,6 +83,13 @@ export default class Oauth2Scheme {
 
   async fetchUser () {
     if (!this.$auth.getToken(this.name)) {
+      return
+    }
+
+    // Decode token
+    if (this.options.userinfo_decode) {
+      const user = jwtDecode(this.$auth.getToken(this.name))
+      this.$auth.setUser(user)
       return
     }
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "cookie": "^0.3.1",
     "dotprop": "^1.0.2",
     "js-cookie": "^2.2.0",
+    "jwt-decode": "^2.2.0",
     "lodash": "^4.17.10"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4630,6 +4630,10 @@ jws@^3.1.4:
     jwa "^1.1.4"
     safe-buffer "^5.0.1"
 
+jwt-decode@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-2.2.0.tgz#7d86bd56679f58ce6a84704a657dd392bba81a79"
+
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"


### PR DESCRIPTION
https://github.com/nuxt-community/auth-module/issues/120

I wasn't able to add a function directly to `nuxt.config.js` (I think the config normalizer wasn't expecting a function) so I added a config prop that will override the `userinfo` ajax call and instead calculate the user object using `JSON.parse(atob(token.split('.')[1]))`.