### PR TITLE
feat: Add onRedirect hook to pre-process URLs before redirection

### DIFF
--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -119,7 +119,8 @@ Pre-process URLs before redirect: (`plugins/auth.js`)
 ```js
 export default function({ app }) {
   app.$auth.onRedirect((to) => {
-    console.error(to)
+    console.log(to)
+    return to
   })
 }
 ```

--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -111,3 +111,15 @@ export default function({ $auth }) {
   })
 }
 ```
+
+### `onRedirect(handler)`
+
+Pre-process URLs before redirect: (`plugins/auth.js`)
+
+```js
+export default function({ app }) {
+  app.$auth.onRedirect((to) => {
+    console.error(to)
+  })
+}
+```

--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -15,7 +15,7 @@ export default class Auth {
     this._errorListeners = []
 
     // Redirect listener
-    this._redirectListener = null
+    this._redirectListeners = []
 
     // Storage & State
     options.initialState = { user: null, loggedIn: false }
@@ -348,14 +348,15 @@ export default class Auth {
   }
 
   onRedirect (listener) {
-    this._redirectListener = listener
+    this._redirectListeners.push(listener)
   }
 
   callOnRedirect (to) {
-    if (!this._redirectListener) {
-      return to
+    for (let fn of this._redirectListeners) {
+      to = fn(to)
     }
-    return this._redirectListener(to)
+
+    return to
   }
 
   hasScope (scope) {

--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -14,6 +14,9 @@ export default class Auth {
     // Error listeners
     this._errorListeners = []
 
+    // Redirect listener
+    this._redirectListener = null
+
     // Storage & State
     options.initialState = { user: null, loggedIn: false }
     const storage = new Storage(ctx, options)
@@ -310,6 +313,8 @@ export default class Auth {
       return
     }
 
+    to = this.callOnRedirect(to)
+
     // Apply rewrites
     if (this.options.rewriteRedirects) {
       if (name === 'login' && isRelativeURL(from) && !isSameURL(to, from)) {
@@ -340,6 +345,17 @@ export default class Auth {
     } else {
       this.ctx.redirect(to)
     }
+  }
+
+  onRedirect (listener) {
+    this._redirectListener = listener
+  }
+
+  callOnRedirect (to) {
+    if (!this._redirectListener) {
+      return to
+    }
+    return this._redirectListener(to)
   }
 
   hasScope (scope) {


### PR DESCRIPTION
This is another proposal to address #162 
It adds an `onRedirect` hook that can be defined in a plugin in order to pre-process the URL before the redirect happens.
To use this with **nuxt-i18n**, you could do something like this:

```js
// ~/plugins/auth.js

export default ({ app }) => {
  $auth.onRedirect(to => {
    return app.localePath(to)
  })
})
```