### PR TITLE
Fixed issues preventing server-side login in oauth2 strategies

### DIFF
--- a/lib/core/utilities.js
+++ b/lib/core/utilities.js
@@ -1,3 +1,5 @@
+const btoa = require('btoa');
+
 export const isUnset = o => typeof o === 'undefined' || o === null
 export const isSet = o => !isUnset(o)
 

--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -29,6 +29,8 @@ export default class Oauth2Scheme {
 
     if (process.browser) {
       return window.location.origin + this.$auth.options.redirect.callback
+    } else if (this.options.base_url) {
+      return this.options.base_url + this.$auth.options.redirect.callback
     }
   }
 
@@ -77,7 +79,11 @@ export default class Oauth2Scheme {
 
     const url = this.options.authorization_endpoint + '?' + encodeQuery(opts)
 
-    window.location = url
+    if (process.browser) {
+      window.location.replace(url)
+    } else {
+      this.$auth.ctx.redirect(url)
+    }
   }
 
   async fetchUser () {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "@nuxtjs/axios": "^5.3.1",
     "boom": "^7.2.0",
+    "btoa": "^1.2.1",
     "consola": "^1.3.0",
     "cookie": "^0.3.1",
     "dotprop": "^1.0.2",


### PR DESCRIPTION
I was trying to use the auth-module to route directly to the auth0 hosted login page, and in doing so was attempting to call `loginWith('auth0')` from the `fetch()` method of `pages/login.vue`. When arriving at the login page after clicking `<router-link to="login">Login</router-link>`, I was redirected properly to auth0's login page, but when navigating directly to `/login` from the browser, the redirect silently failed and I was left on an empty login view. When I went searching for issues, I found two:

* The `randomString()` method leverages btoa which is available in the browser, but not server-side. I installed the `btoa` package and required it in the utilities file to resolve this silent error.
* The login redirect calls all used `window.location` and didn't look to see if we were client side or server side. Added in checks and used `this.$auth.ctx.redirect()` accordingly.

The only part I couldn't figure out how to resolve gracefully was the fact that the generation of the redirect_url for oauth requests needed the origin base_url which can't be grabbed server-side as easily. I left the code to use the origin dynamically when initiating client-side, but had to add an option to the configuration settings, `base_url`, that would allow for developers to manually specify the redirect origin for the oauth provider. 