### PR TITLE
Feature: local strategy refresh

### DIFF
--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -157,6 +157,7 @@ export default class Auth {
       this.setUser(false)
       this.setToken(this.$state.strategy, false)
       this.setRefreshToken(this.$state.strategy, false)
+      this.setExpiration(this.$state.strategy, false)
       return Promise.resolve()
     }
 

--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -189,6 +189,28 @@ export default class Auth {
   }
 
   // ---------------------------------------------------------------
+  // Token Expiration helpers
+  // ---------------------------------------------------------------
+
+  getExpiration (strategy) {
+    const _key = this.options.token_expiration.prefix + strategy
+
+    return this.$storage.getUniversal(_key)
+  }
+
+  setExpiration (strategy, token) {
+    const _key = this.options.token_expiration.prefix + strategy
+
+    return this.$storage.setUniversal(_key, token)
+  }
+
+  syncExpiration (strategy) {
+    const _key = this.options.token_expiration.prefix + strategy
+
+    return this.$storage.syncUniversal(_key)
+  }
+
+  // ---------------------------------------------------------------
   // Refresh token helpers
   // ---------------------------------------------------------------
 
@@ -251,11 +273,7 @@ export default class Auth {
     return this.ctx.app.$axios
       .request(_endpoint)
       .then(response => {
-        if (_endpoint.propertyName) {
-          return getProp(response.data, _endpoint.propertyName)
-        } else {
-          return response.data
-        }
+        return response.data
       })
       .catch(error => {
         // Call all error handlers

--- a/lib/module/defaults.js
+++ b/lib/module/defaults.js
@@ -49,6 +49,12 @@ module.exports = {
     prefix: '_token.'
   },
 
+  // -- Token Expiration --
+
+  token_expiration: {
+    prefix: '_token_expires_at.'
+  },
+
   // -- Refresh token --
 
   refresh_token: {

--- a/lib/schemes/local.js
+++ b/lib/schemes/local.js
@@ -2,6 +2,7 @@ export default class LocalScheme {
   constructor (auth, options) {
     this.$auth = auth
     this.name = options._name
+    this.refreshInterval = undefined
 
     this.options = Object.assign({}, DEFAULTS, options)
   }
@@ -20,15 +21,67 @@ export default class LocalScheme {
     }
   }
 
-  mounted () {
+  _updateTokens (result) {
+    let accessToken = result[this.options.endpoints.login.propertyName]
+
+    //extract refresh token and set expiration
+    if (this.options.refreshToken) {
+      var tokenCreatedAt = result['created_at'] || Date.now
+      var refreshToken = result[this.options.refreshToken]
+      var tokenExpiration = tokenCreatedAt + result['expires_in']
+    }
+
     if (this.options.tokenRequired) {
+      const token = this.options.tokenType ? this.options.tokenType + ' ' + accessToken : accessToken
+
+      // update access token
+      this.$auth.setToken(this.name, token)
+      this._setToken(token)
+
+      // update refresh token and register refresh-logic with axios
+      if ( refreshToken !== undefined) {
+        this.$auth.setRefreshToken(this.name, refreshToken)
+        this.$auth.setExpiration(this.name, tokenExpiration * 1000)
+      }
+    }
+  }
+
+  _tokenRefresh (self) {
+    return this.$auth.ctx.app.$axios.post(
+      this.options.endpoints.login.url,
+      {
+        refresh_token: this.$auth.getRefreshToken(this.name),
+        client_id: this.options.client_id,
+        grant_type: 'refresh_token'
+      }
+    ).then(response => {
+      this._updateTokens(response.data)
+    }).catch(err => {
+      this.logout()
+    })
+  }
+
+  _scheduleTokenRefresh () {
+    let self = this
+    let intervalDuration = (self.$auth.getExpiration(self.name) - Date.now()) * 0.75
+
+    this.refreshInterval = setInterval(function () {
+      console.log("iterate")
+      self._tokenRefresh()
+    }, intervalDuration);
+  }
+
+  mounted () {
+    if (this.options.tokenRequired && this.$auth.loggedIn) {
       const token = this.$auth.syncToken(this.name)
       this._setToken(token)
 
       if (this.options.refreshToken) {
-        const token = this.$auth.syncRefreshToken(this.name)
-        this._refreshToken()
-        this.$auth.syncExpiration(this.name)
+        this.$auth.syncRefreshToken(this.name)
+        this._tokenRefresh().then(() => {
+          this.$auth.syncExpiration(this.name)
+          this._scheduleTokenRefresh()
+        })
       }
     }
 
@@ -49,6 +102,7 @@ export default class LocalScheme {
     )
 
     this._updateTokens(result)
+    this._scheduleTokenRefresh()
 
     return this.fetchUser()
   }
@@ -90,102 +144,9 @@ export default class LocalScheme {
     if (this.options.tokenRequired) {
       this._clearToken()
     }
+    clearInterval(this.refreshInterval)
 
     return this.$auth.reset()
-  }
-
-  _refreshToken () {
-    const { $axios } = this.$auth.ctx.app
-
-    refreshPromise = $axios.post(
-      this.options.endpoints.login.url,
-      {
-        refresh_token: refreshToken,
-        client_id: this.options.client_id,
-        grant_type: 'refresh_token'
-      }
-    ).then(response => {
-      this._updateTokens(response.data)
-    }).catch(err => {
-      this.logout()
-    })
-    // const { $axios } = this.$auth.ctx.app
-    // var refreshPromise = undefined
-
-    // $axios.onRequest((config) => {
-    //   // token and refresh token
-    //   let token = this.$auth.getToken(this.name)
-    //   let refreshToken = this.$auth.getRefreshToken(this.name)
-
-    //   // Check if the tokens are set, i.e. user is logged in
-    //   if (!token || !refreshToken || !token.length || !refreshToken.length) {
-    //     return config
-    //   }
-
-    //   // token if token is still valid
-    //   const now = Date.now()
-    //   if (now < this.$auth.getExpiration(this.name)) {
-    //     return config
-    //   }
-
-    //   // if (refreshPromise) {
-    //   //   console.log("pre await")
-    //   //   await refreshPromise
-    //   //   console.log("post await")
-    //   // } else {
-    //   // Try to refresh token before processing current request
-    //     refreshPromise = $axios.post(
-    //       this.options.endpoints.login.url,
-    //       {
-    //         refresh_token: refreshToken,
-    //         client_id: this.options.client_id,
-    //         grant_type: 'refresh_token'
-    //       }
-    //     ).then(response => {
-    //       console.log("success")
-
-    //       refreshPromise = undefined
-
-    //       // Change flag
-    //       this._updateTokens(response.data)
-
-    //       return Promise.resolve(config)
-    //     }).catch(err => {
-    //       console.log("fail")
-
-    //       refreshPromise = undefined
-
-    //       this.logout()
-    //     })
-    //   // }
-
-    //   config.headers['Authorization'] = this.$auth.getToken(this.name)
-    // })
-  }
-
-  _updateTokens (result) {
-    let accessToken = result[this.options.endpoints.login.propertyName]
-
-    //extract refresh token and set expiration
-    if (this.options.refreshToken) {
-      var tokenCreatedAt = result['created_at'] || Date.now
-      var refreshToken = result[this.options.refreshToken]
-      var tokenExpiration = tokenCreatedAt + result['expires_in']
-    }
-
-    if (this.options.tokenRequired) {
-      const token = this.options.tokenType ? this.options.tokenType + ' ' + accessToken : accessToken
-
-      // update access token
-      this.$auth.setToken(this.name, token)
-      this._setToken(token)
-
-      // update refresh token and register refresh-logic with axios
-      if ( refreshToken !== undefined) {
-        this.$auth.setRefreshToken(this.name, refreshToken)
-        this.$auth.setExpiration(this.name, tokenExpiration * 1000)
-      }
-    }
   }
 }
 

--- a/lib/schemes/local.js
+++ b/lib/schemes/local.js
@@ -64,6 +64,10 @@ export default class LocalScheme {
   _scheduleTokenRefresh () {
     let self = this
     let intervalDuration = (self.$auth.getExpiration(self.name) - Date.now()) * 0.75
+    if (intervalDuration < 1000) {
+      // in case you misconfigured refreshing this will save your auth-server from a self-induced DDoS-Attack
+      intervalDuration = 1000
+    }
 
     this.refreshInterval = setInterval(function () {
       console.log("iterate")
@@ -102,7 +106,9 @@ export default class LocalScheme {
     )
 
     this._updateTokens(result)
-    this._scheduleTokenRefresh()
+    if (this.options.refreshToken) {
+      this._scheduleTokenRefresh()
+    }
 
     return this.fetchUser()
   }

--- a/lib/schemes/local.js
+++ b/lib/schemes/local.js
@@ -24,6 +24,12 @@ export default class LocalScheme {
     if (this.options.tokenRequired) {
       const token = this.$auth.syncToken(this.name)
       this._setToken(token)
+
+      if (this.options.refreshToken) {
+        const token = this.$auth.syncRefreshToken(this.name)
+        this._refreshToken()
+        this.$auth.syncExpiration(this.name)
+      }
     }
 
     return this.$auth.fetchUserOnce()
@@ -42,14 +48,7 @@ export default class LocalScheme {
       this.options.endpoints.login
     )
 
-    if (this.options.tokenRequired) {
-      const token = this.options.tokenType
-        ? this.options.tokenType + ' ' + result
-        : result
-
-      this.$auth.setToken(this.name, token)
-      this._setToken(token)
-    }
+    this._updateTokens(result)
 
     return this.fetchUser()
   }
@@ -94,9 +93,104 @@ export default class LocalScheme {
 
     return this.$auth.reset()
   }
+
+  _refreshToken () {
+    const { $axios } = this.$auth.ctx.app
+
+    refreshPromise = $axios.post(
+      this.options.endpoints.login.url,
+      {
+        refresh_token: refreshToken,
+        client_id: this.options.client_id,
+        grant_type: 'refresh_token'
+      }
+    ).then(response => {
+      this._updateTokens(response.data)
+    }).catch(err => {
+      this.logout()
+    })
+    // const { $axios } = this.$auth.ctx.app
+    // var refreshPromise = undefined
+
+    // $axios.onRequest((config) => {
+    //   // token and refresh token
+    //   let token = this.$auth.getToken(this.name)
+    //   let refreshToken = this.$auth.getRefreshToken(this.name)
+
+    //   // Check if the tokens are set, i.e. user is logged in
+    //   if (!token || !refreshToken || !token.length || !refreshToken.length) {
+    //     return config
+    //   }
+
+    //   // token if token is still valid
+    //   const now = Date.now()
+    //   if (now < this.$auth.getExpiration(this.name)) {
+    //     return config
+    //   }
+
+    //   // if (refreshPromise) {
+    //   //   console.log("pre await")
+    //   //   await refreshPromise
+    //   //   console.log("post await")
+    //   // } else {
+    //   // Try to refresh token before processing current request
+    //     refreshPromise = $axios.post(
+    //       this.options.endpoints.login.url,
+    //       {
+    //         refresh_token: refreshToken,
+    //         client_id: this.options.client_id,
+    //         grant_type: 'refresh_token'
+    //       }
+    //     ).then(response => {
+    //       console.log("success")
+
+    //       refreshPromise = undefined
+
+    //       // Change flag
+    //       this._updateTokens(response.data)
+
+    //       return Promise.resolve(config)
+    //     }).catch(err => {
+    //       console.log("fail")
+
+    //       refreshPromise = undefined
+
+    //       this.logout()
+    //     })
+    //   // }
+
+    //   config.headers['Authorization'] = this.$auth.getToken(this.name)
+    // })
+  }
+
+  _updateTokens (result) {
+    let accessToken = result[this.options.endpoints.login.propertyName]
+
+    //extract refresh token and set expiration
+    if (this.options.refreshToken) {
+      var tokenCreatedAt = result['created_at'] || Date.now
+      var refreshToken = result[this.options.refreshToken]
+      var tokenExpiration = tokenCreatedAt + result['expires_in']
+    }
+
+    if (this.options.tokenRequired) {
+      const token = this.options.tokenType ? this.options.tokenType + ' ' + accessToken : accessToken
+
+      // update access token
+      this.$auth.setToken(this.name, token)
+      this._setToken(token)
+
+      // update refresh token and register refresh-logic with axios
+      if ( refreshToken !== undefined) {
+        this.$auth.setRefreshToken(this.name, refreshToken)
+        this.$auth.setExpiration(this.name, tokenExpiration * 1000)
+      }
+    }
+  }
 }
 
 const DEFAULTS = {
+  refreshToken: false,
   tokenRequired: true,
   tokenType: 'Bearer',
   globalToken: true,


### PR DESCRIPTION
Hello maintainers,

at first: thank you for this well documented authentication module! The general quality of documentation and the number of examples in the Nuxt world really makes me a happy dev.

Now to my PR: I saw https://github.com/nuxt-community/auth-module/pull/188 by robsontenorio and he mentioned that refreshing for the local strategy would be similar efforts.
As I currently use the local-scheme to authenticate against my rails-doorkeeper oauth2-api with 'password'-flow I started developing on this feature.

I noticed that @robsontenorio 's onRequest-way has a serious drawback: My App fires like 2-3 parallel requests when I switch a page. His onRequest-axios-handler will initiate the refresh on the first request, but all requests afterwards (until the refresh is finished) will 401 as they saw the "isRefreshing"-flag and just continue execution.

So I decided to go with a simple setInterval for starters which will refresh the session as long as the user has his browser window open. To mitigate 401s (and just be on the save side) I calculate the interval to be 75% of the tokens lifetime.

I extended the configuration of the local-scheme by a new option: refresh_token. It defaults to "false" which means no refreshing is gonna happen. In case it's set (e.g. 'refresh_token_name') the refreshing-mechanism will jump into action and look for a refresh_token with the specified name next to the access_token on login.