### PR TITLE
bug fixed, still loggedIn after log out

### DIFF
--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -230,7 +230,7 @@ export default class Auth {
   }
 
   setUser (user) {
-    this.$storage.setState('loggedIn', Boolean(user))
+    (user == {}) ? this.$storage.setState('loggedIn', false) : this.$storage.setState('loggedIn', Boolean(user))
     this.$storage.setState('user', user)
   }
 


### PR DESCRIPTION
Since the boolean value of empty object is true, loggedIn status keeps true even after logging out.