### PR TITLE
Add audience to Auth0 request. Fixes #176.

### DIFF
--- a/lib/providers/_utils.js
+++ b/lib/providers/_utils.js
@@ -6,10 +6,11 @@ function assignDefaults (strategy, defaults) {
 }
 
 function addAuthorize (strategy) {
-  // Get client_secret, client_id and token_endpoint
+  // Get client_secret, client_id, token_endpoint and audience
   const clientSecret = strategy.client_secret
   const clientID = strategy.client_id
   const tokenEndpoint = strategy.token_endpoint
+  const audience = strategy.audience
 
   // IMPORTANT: remove client_secret from generated bundle
   delete strategy.client_secret
@@ -54,6 +55,7 @@ function addAuthorize (strategy) {
               grant_type: grantType,
               response_type: responseType,
               redirect_uri: redirectUri,
+              audience: audience,
               code
             },
             headers: {

--- a/lib/providers/auth0.js
+++ b/lib/providers/auth0.js
@@ -5,6 +5,7 @@ module.exports = function auth0 (strategy) {
     _scheme: 'oauth2',
     authorization_endpoint: `https://${strategy.domain}/authorize`,
     userinfo_endpoint: `https://${strategy.domain}/userinfo`,
-    scope: ['openid', 'profile', 'email']
+    scope: ['openid', 'profile', 'email'],
+    audience: strategy.domain
   })
 }

--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -70,6 +70,7 @@ export default class Oauth2Scheme {
       client_id: this.options.client_id,
       redirect_uri: this._redirectURI,
       scope: this._scope,
+      audience: this.options.audience,
       state: randomString()
     }
 
@@ -125,6 +126,7 @@ export default class Oauth2Scheme {
           client_id: this.options.client_id,
           redirect_uri: this._redirectURI,
           response_type: this.options.response_type,
+          audience: this.options.audience,
           grant_type: this.options.grant_type
         })
       })


### PR DESCRIPTION
Allows and defaults to adding audience field to Auth0 requests in order to return a JWT. Fixes #176.