### PR TITLE
Add Discord provider, and auto token refresh for OAuth

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,9 @@ module.exports = {
     // Allow debugger during development
     'no-debugger': process.env.NODE_ENV === 'production' ? 2 : 0,
     // Do not allow console.logs etc...
-    'no-console': 2
+    'no-console': 2,
+    // Allow non-camelcase for OAuth
+    'camelcase': 0,
   },
   globals: {
     'jest/globals': true,

--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -211,6 +211,28 @@ export default class Auth {
   }
 
   // ---------------------------------------------------------------
+  // Expires at helpers
+  // ---------------------------------------------------------------
+
+  getExpiresAt (strategy) {
+    const _key = this.options.expires_at.prefix + strategy
+
+    return this.$storage.getUniversal(_key)
+  }
+
+  setExpiresAt (strategy, expiresAt) {
+    const _key = this.options.expires_at.prefix + strategy
+
+    return this.$storage.setUniversal(_key, expiresAt)
+  }
+
+  syncExpiresAt (strategy) {
+    const _key = this.options.expires_at.prefix + strategy
+
+    return this.$storage.syncUniversal(_key)
+  }
+
+  // ---------------------------------------------------------------
   // User helpers
   // ---------------------------------------------------------------
 

--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -134,7 +134,7 @@ export default class Auth {
       return Promise.resolve()
     }
 
-    return Promise.resolve(this.strategy.fetchUser(...arguments)).catch(error => {
+    return Promise.resolve(this.strategy.fetchUser(...arguments)).catch(async error => {
       this.callOnError(error, { method: 'fetchUser' })
       return Promise.reject(error)
     })

--- a/lib/core/utilities.js
+++ b/lib/core/utilities.js
@@ -29,8 +29,7 @@ export const randomString = () => {
   if (process.client || process.browser) {
     return btoa(Math.random() + '').replace('==', '')
   } else if (process.server) {
-    let crypto = require('crypto')
-    return crypto.randomBytes(12).toString('hex')
+    return require('crypto').randomBytes(12).toString('hex')
   }
 }
 

--- a/lib/core/utilities.js
+++ b/lib/core/utilities.js
@@ -25,7 +25,14 @@ export const encodeQuery = queryObject => {
     .join('&')
 }
 
-export const randomString = () => btoa(Math.random() + '').replace('==', '')
+export const randomString = () => {
+  if (process.client || process.browser) {
+    return btoa(Math.random() + '').replace('==', '')
+  } else if (process.server) {
+    let crypto = require('crypto')
+    return crypto.randomBytes(12).toString('hex')
+  }
+}
 
 export const routeOption = (route, key, value) => {
   return route.matched.some(m => {

--- a/lib/module/defaults.js
+++ b/lib/module/defaults.js
@@ -15,6 +15,8 @@ module.exports = {
 
   watchLoggedIn: true,
 
+  logoutOnError: false,
+
   redirect: {
     login: '/login',
     logout: '/',

--- a/lib/module/defaults.js
+++ b/lib/module/defaults.js
@@ -55,6 +55,10 @@ module.exports = {
     prefix: '_refresh_token.'
   },
 
+  expires_at: {
+    prefix: '_expires_at.'
+  },
+
   // -- Strategies --
 
   defaultStrategy: undefined /* will be auto set at module level */,

--- a/lib/providers/_utils.js
+++ b/lib/providers/_utils.js
@@ -1,11 +1,14 @@
+// No point in renaming and re-renaming API values
+/* eslint camelcase: 0 */
+
 const axios = require('axios')
 const bodyParser = require('body-parser')
 
-function assignDefaults(strategy, defaults) {
+function assignDefaults (strategy, defaults) {
   Object.assign(strategy, Object.assign({}, defaults, strategy))
 }
 
-function addAuthorize(strategy) {
+function addAuthorize (strategy) {
   // Get client_secret, client_id and token_endpoint
   const {
     client_id,

--- a/lib/providers/_utils.js
+++ b/lib/providers/_utils.js
@@ -1,15 +1,17 @@
 const axios = require('axios')
 const bodyParser = require('body-parser')
 
-function assignDefaults (strategy, defaults) {
+function assignDefaults(strategy, defaults) {
   Object.assign(strategy, Object.assign({}, defaults, strategy))
 }
 
-function addAuthorize (strategy) {
+function addAuthorize(strategy) {
   // Get client_secret, client_id and token_endpoint
-  const clientSecret = strategy.client_secret
-  const clientID = strategy.client_id
-  const tokenEndpoint = strategy.token_endpoint
+  const {
+    client_id,
+    client_secret,
+    token_endpoint: tokenEndpoint
+  } = strategy
 
   // IMPORTANT: remove client_secret from generated bundle
   delete strategy.client_secret
@@ -35,31 +37,47 @@ function addAuthorize (strategy) {
       formMiddleware(req, res, () => {
         const {
           code,
-          redirect_uri: redirectUri = strategy.redirect_uri,
-          response_type: responseType = strategy.response_type,
-          grant_type: grantType = strategy.grant_type
+          redirect_uri = strategy.redirect_uri,
+          response_type = strategy.response_type,
+          grant_type = strategy.grant_type
         } = req.body
 
         if (!code) {
           return next()
         }
 
-        axios
-          .request({
-            method: 'post',
-            url: tokenEndpoint,
-            data: {
-              client_id: clientID,
-              client_secret: clientSecret,
-              grant_type: grantType,
-              response_type: responseType,
-              redirect_uri: redirectUri,
-              code
-            },
-            headers: {
-              Accept: 'application/json'
-            }
+        let data = {
+          response_type,
+          grant_type,
+          redirect_uri,
+          code
+        }
+
+        let options = {
+          headers: {
+            Accept: 'application/json'
+          }
+        }
+
+        if (strategy.tokenParams) {
+          options.params = data
+          data = {}
+        } else {
+          Object.assign(data, {
+            client_id,
+            client_secret
           })
+        }
+
+        if (strategy.authHeader) {
+          options.auth = {
+            username: client_id,
+            password: client_secret
+          }
+        }
+
+        axios
+          .post(tokenEndpoint, data, options)
           .then(response => {
             res.end(JSON.stringify(response.data))
           })

--- a/lib/providers/_utils.js
+++ b/lib/providers/_utils.js
@@ -1,6 +1,3 @@
-// No point in renaming and re-renaming API values
-/* eslint camelcase: 0 */
-
 const axios = require('axios')
 const bodyParser = require('body-parser')
 
@@ -18,6 +15,10 @@ function addAuthorize (strategy) {
 
   // IMPORTANT: remove client_secret from generated bundle
   delete strategy.client_secret
+
+  if (strategy.access_token_endpoint) {
+    return
+  }
 
   // Endpoint
   const endpoint = `/_auth/oauth/${strategy._name}/authorize`

--- a/lib/providers/discord.js
+++ b/lib/providers/discord.js
@@ -1,0 +1,18 @@
+const { assignDefaults, addAuthorize } = require('./_utils')
+
+module.exports = function discord (strategy) {
+  assignDefaults(strategy, {
+    _scheme: 'oauth2',
+    authorization_endpoint: 'https://discordapp.com/api/oauth2/authorize',
+    token_endpoint: 'https://discordapp.com/api/oauth2/token',
+    userinfo_endpoint: 'https://discordapp.com/api/users/@me',
+    response_type: 'code',
+    grant_type: 'authorization_code',
+    tokenParams: true,
+    authHeader: true,
+
+    scope: ['identify', 'email']
+  })
+
+  addAuthorize.call(this, strategy)
+}

--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -59,9 +59,15 @@ export default class Oauth2Scheme {
   async mounted () {
     // Sync token
     const token = this.$auth.syncToken(this.name)
+    const refreshToken = this.$auth.syncRefreshToken(this.name)
+    const expiresAt = this.$auth.syncExpiresAt(this.name)
     // Set axios token
     if (token) {
       this._setToken(token)
+
+      if (refreshToken && expiresAt) {
+        this._scheduleTokenRefresh(refreshToken, expiresAt)
+      }
     }
 
     // Handle callbacks on page load
@@ -70,6 +76,7 @@ export default class Oauth2Scheme {
       if (!token && process.server && this.options.autoLogin) {
         let path = this.options.autoLogin === true ? (this.$auth.options.redirect.callback + '/' + this.name) : this.options.autoLogin
         let route = this.$auth.ctx.route
+        console.log(path, route)
         if (route.path === path && Object.keys(route.query).length === 0) {
           return this.login()
         }
@@ -86,6 +93,80 @@ export default class Oauth2Scheme {
   _clearToken () {
     // Clear Authorization token for all axios requests
     this.$auth.ctx.app.$axios.setHeader(this.options.tokenName, false)
+    if (this.refreshTimeout) {
+      clearTimeout(this.refreshTimeout)
+    }
+  }
+
+  _scheduleTokenRefresh (refreshToken, expiresAt) {
+    if (this.refreshTimeout) {
+      return
+    }
+
+    if (~refreshToken.indexOf(' ')) {
+      refreshToken = refreshToken.split(' ')[1]
+    }
+
+    let time = expiresAt - Date.now()
+    if (time < 1000) time = 1000
+
+    this.$auth.setExpiresAt(this.name, expiresAt)
+    this.refreshTimeout = setTimeout(() => {
+      this.refreshTimeout = 0
+      return this._fetchToken({ refreshToken })
+    }, time)
+  }
+
+  async _fetchToken (options = {}) {
+    let token, refreshToken, expiresIn
+
+    if (options.code || options.refreshToken) {
+      const data = await this.$auth.request({
+        method: 'post',
+        url: this.options.access_token_endpoint,
+        baseURL: false,
+        data: {
+          client_id: this.options.client_id,
+          redirect_uri: this._redirectURI,
+          response_type: this.options.response_type,
+          grant_type: options.refreshToken ? 'refresh_token' : this.options.grant_type,
+          code: options.code,
+          refresh_token: options.refreshToken
+        }
+      })
+
+      if (data.access_token) {
+        token = data.access_token
+      }
+
+      if (data.refresh_token) {
+        refreshToken = data.refresh_token
+        expiresIn = data.expires_in
+      }
+    }
+
+    // Append token_type
+    if (this.options.token_type) {
+      token = this.options.token_type + ' ' + token
+    }
+
+    // Store token
+    this.$auth.setToken(this.name, token)
+
+    // Set axios token
+    this._setToken(token)
+
+    // Store refresh token
+    if (refreshToken && refreshToken.length) {
+      refreshToken = this.options.token_type + ' ' + refreshToken
+      this.$auth.setRefreshToken(this.name, refreshToken)
+      this._scheduleTokenRefresh(refreshToken, Date.now() + (expiresIn * 950)) // 95% of expiration time
+    }
+
+    return {
+      token,
+      refreshToken
+    }
   }
 
   async logout () {
@@ -150,30 +231,7 @@ export default class Oauth2Scheme {
 
     // -- Authorization Code Grant --
     if (this.options.response_type === 'code' && parsedQuery.code) {
-      const data = await this.$auth.request({
-        method: 'post',
-        url: this.options.access_token_endpoint,
-        baseURL: false,
-        data: encodeQuery({
-          code: parsedQuery.code,
-          client_id: this.options.client_id,
-          redirect_uri: this._redirectURI,
-          response_type: this.options.response_type,
-          grant_type: this.options.grant_type
-        })
-      })
-
-      if (data.access_token) {
-        token = data.access_token
-      }
-
-      if (data.refresh_token) {
-        refreshToken = data.refresh_token
-      }
-    }
-
-    if (!token || !token.length) {
-      return
+      await this._fetchToken({ code: parsedQuery.code, token, refreshToken })
     }
 
     // Validate state
@@ -181,23 +239,6 @@ export default class Oauth2Scheme {
     this.$auth.$storage.setLocalStorage(this.name + '.state', null)
     if (state && parsedQuery.state !== state) {
       return
-    }
-
-    // Append token_type
-    if (this.options.token_type) {
-      token = this.options.token_type + ' ' + token
-    }
-
-    // Store token
-    this.$auth.setToken(this.name, token)
-
-    // Set axios token
-    this._setToken(token)
-
-    // Store refresh token
-    if (refreshToken && refreshToken.length) {
-      refreshToken = this.options.token_type + ' ' + refreshToken
-      this.$auth.setRefreshToken(this.name, refreshToken)
     }
 
     // Redirect to home

--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -43,7 +43,7 @@ export default class Oauth2Scheme {
           baseUrl = this.$auth.ctx.$axios.defaults.baseURL
         } else {
           // Generate url from options or request
-          let protocol = this.options.protocol || this.$auth.options.redirect.protocol || 'http'
+          let protocol = this.options.protocol || this.$auth.options.redirect.protocol || 'https'
           let host = this.options.host || this.$auth.options.redirect.host || this.$auth.ctx.req.headers.host
           baseUrl = protocol + '://' + host
         }

--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -3,7 +3,10 @@ import { encodeQuery, parseQuery, randomString } from '../utilities'
 const DEFAULTS = {
   token_type: 'Bearer',
   response_type: 'token',
-  tokenName: 'Authorization'
+  tokenName: 'Authorization',
+  autoLogin: false,
+  tokenParams: false,
+  authHeader: false
 }
 
 export default class Oauth2Scheme {
@@ -27,8 +30,29 @@ export default class Oauth2Scheme {
       return url
     }
 
-    if (process.browser) {
-      return window.location.origin + this.$auth.options.redirect.callback
+    // Generate redirect url if none provided
+    if (!url) {
+      let baseUrl
+
+      // Browser was here before, but client is documented, so I'm using client
+      if (process.client || process.browser) {
+        baseUrl = window.location.origin
+      } else if (process.server) {
+        // Attempt to grab baseUrl from axios if it exists
+        if (this.$auth.ctx.$axios && this.$auth.ctx.$axios.defaults && this.$auth.ctx.$axios.defaults.baseURL) {
+          baseUrl = this.$auth.ctx.$axios.defaults.baseURL
+        } else {
+          // Generate url from options or request
+          let protocol = this.options.protocol || this.$auth.options.redirect.protocol || 'http'
+          let host = this.options.host || this.$auth.options.redirect.host || this.$auth.ctx.req.headers.host
+          baseUrl = protocol + '://' + host
+        }
+      }
+
+      // Remove trailing slashes
+      baseUrl = baseUrl.replace(/^\/|\/$/g, '')
+
+      return baseUrl + this.$auth.options.redirect.callback
     }
   }
 
@@ -42,8 +66,14 @@ export default class Oauth2Scheme {
 
     // Handle callbacks on page load
     const redirected = await this._handleCallback()
-
     if (!redirected) {
+      if (!token && process.server && this.options.autoLogin) {
+        let path = this.options.autoLogin === true ? (this.$auth.options.redirect.callback + '/' + this.name) : this.options.autoLogin
+        let route = this.$auth.ctx.route
+        if (route.path === path && Object.keys(route.query).length === 0) {
+          return this.login()
+        }
+      }
       return this.$auth.fetchUserOnce()
     }
   }
@@ -77,7 +107,11 @@ export default class Oauth2Scheme {
 
     const url = this.options.authorization_endpoint + '?' + encodeQuery(opts)
 
-    window.location = url
+    if (process.client || process.browser) {
+      window.location = url
+    } else if (process.server) {
+      this.$auth.ctx.redirect(url)
+    }
   }
 
   async fetchUser () {
@@ -97,7 +131,7 @@ export default class Oauth2Scheme {
     this.$auth.setUser(user)
   }
 
-  async _handleCallback (uri) {
+  async _handleCallback () {
     // Callback flow is not supported in server side
     if (process.server) {
       return

--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -69,20 +69,33 @@ export default class Oauth2Scheme {
         this._scheduleTokenRefresh(refreshToken, expiresAt)
       }
     }
-
     // Handle callbacks on page load
     const redirected = await this._handleCallback()
     if (!redirected) {
-      if (!token && process.server && this.options.autoLogin) {
+      if (!token && this.options.autoLogin) {
         let path = this.options.autoLogin === true ? (this.$auth.options.redirect.callback + '/' + this.name) : this.options.autoLogin
-        let route = this.$auth.ctx.route
-        console.log(path, route)
-        if (route.path === path && Object.keys(route.query).length === 0) {
-          return this.login()
+        if (process.client || process.browser) {
+          if (location.pathname === path && location.search.length === 0) {
+            return this.login()
+          }
+        } else if (process.server) {
+          let route = this.$auth.ctx.route
+          if (route.path === path && Object.keys(route.query).length === 0) {
+            return this.login()
+          }
         }
       }
       return this.$auth.fetchUserOnce()
     }
+  }
+
+  // Handle resetting properly
+  reset () {
+    this._clearToken()
+    this.$auth.setUser(false)
+    this.$auth.setToken(this.name, false)
+    this.$auth.setRefreshToken(this.name, false)
+    this.$auth.setExpiresAt(this.name, false)
   }
 
   _setToken (token) {
@@ -230,9 +243,12 @@ export default class Oauth2Scheme {
     let refreshToken = parsedQuery[this.options.refresh_token_key || 'refresh_token']
 
     // -- Authorization Code Grant --
-    if (this.options.response_type === 'code' && parsedQuery.code) {
-      await this._fetchToken({ code: parsedQuery.code, token, refreshToken })
+    if (this.options.response_type !== 'code' || !parsedQuery.code) {
+      return
     }
+    
+    // Fetch token
+    await this._fetchToken({ code: parsedQuery.code, token, refreshToken })
 
     // Validate state
     const state = this.$auth.$storage.getLocalStorage(this.name + '.state')


### PR DESCRIPTION
Options added are

```js
autoLogin: Boolean | String // Can be true to just use callback + /providerName, or a string for the URL you want to redirect (i.e. /login)
tokenParams: Boolean // Pass token request as search params instead of POST body
authHeader: Boolean // Pass client_id and client_secret as `auth` to axios
```

Both last two are required for Discord. Also added parsing for `_redirectURI()` so it'll work on the server, and `randomString()` now uses `crypto` on the server instead of doing nothing.