### PR TITLE
Documentation fix: propertyName needed to grab the full API response

### DIFF
--- a/docs/schemes/local.md
+++ b/docs/schemes/local.md
@@ -34,7 +34,7 @@ Each endpoint is used to make requests using axios. They are basically extending
 
 #### `propertyName`
 
-`propertyName` can be used to specify which field of the response JSON to be used for value. It can be `undefined` to directly use API response or being more complicated like `auth.user`.
+`propertyName` can be used to specify which field of the response JSON to be used for value. It can be `false` to directly use API response or being more complicated like `auth.user`.
 
 ### `tokenRequired`
 


### PR DESCRIPTION
Setting propertyName to `undefined` forces the default value because of [Object.assign()](https://github.com/nuxt-community/auth-module/blob/dev/lib/core/auth.js#L248).

propertyName should be not undefined but falsy for Object.assign() not to rewrite it.