### PR TITLE
fix(auth): add path helper function

### DIFF
--- a/lib/core/middleware.js
+++ b/lib/core/middleware.js
@@ -15,11 +15,19 @@ Middleware.auth = function (ctx) {
   }
 
   const { login, callback } = ctx.app.$auth.options.redirect
-
+  const splitPath = path => {
+    // remove query string
+    let result = path.split('?')[0]
+    // remove redundant / from the end of path
+    if (result.charAt(result.length - 1) === '/') {
+      result = result.slice(0, -1)
+    }
+    return result
+  }
   if (ctx.app.$auth.$state.loggedIn) {
     // -- Authorized --
     // Redirect to home page if inside login page (or login page disabled)
-    if (!login || ctx.route.path === login.split('?')[0]) {
+    if (!login || splitPath(ctx.route.path) === login) {
       ctx.app.$auth.redirect('home')
     }
   } else {

--- a/lib/core/middleware.js
+++ b/lib/core/middleware.js
@@ -1,5 +1,5 @@
 import Middleware from '../middleware'
-import { routeOption, getMatchedComponents } from './utilities'
+import { routeOption, getMatchedComponents, normalizePath } from './utilities'
 
 Middleware.auth = function (ctx) {
   // Disable middleware if options: { auth: false } is set on the route
@@ -15,19 +15,11 @@ Middleware.auth = function (ctx) {
   }
 
   const { login, callback } = ctx.app.$auth.options.redirect
-  const splitPath = path => {
-    // remove query string
-    let result = path.split('?')[0]
-    // remove redundant / from the end of path
-    if (result.charAt(result.length - 1) === '/') {
-      result = result.slice(0, -1)
-    }
-    return result
-  }
+
   if (ctx.app.$auth.$state.loggedIn) {
     // -- Authorized --
     // Redirect to home page if inside login page (or login page disabled)
-    if (!login || splitPath(ctx.route.path) === login) {
+    if (!login || normalizePath(ctx.route.path) === normalizePath(login)) {
       ctx.app.$auth.redirect('home')
     }
   } else {
@@ -35,7 +27,7 @@ Middleware.auth = function (ctx) {
     // Redirect to login page if not authorized and not inside callback page
     // (Those passing `callback` at runtime need to mark their callback component
     // with `auth: false` to avoid an unnecessary redirect from callback to login)
-    if (!callback || ctx.route.path !== callback.split('?')[0]) {
+    if (!callback || normalizePath(ctx.route.path) !== normalizePath(callback)) {
       ctx.app.$auth.redirect('login')
     }
   }

--- a/lib/core/utilities.js
+++ b/lib/core/utilities.js
@@ -53,3 +53,15 @@ export const getMatchedComponents = (route, matches = false) => {
     })
   }))
 }
+
+export function normalizePath (path = '') {
+  // Remove query string
+  let result = path.split('?')[0]
+
+  // Remove redundant / from the end of path
+  if (result.charAt(result.length - 1) === '/') {
+    result = result.slice(0, -1)
+  }
+
+  return result
+}


### PR DESCRIPTION
In middleware.js file it checks for login route to redirect:
```
if (!login || ctx.route.path === login.split('?')[0]) {
      ctx.app.$auth.redirect('home')
}
```
the `login ` is   `const { login, callback } = ctx.app.$auth.options.redirect` so it is constant.
for example `/login`. In `if` condition it should split `ctx.route.path` and then checks it with login.
And there is another problem. In some cases the login route path is `/login/`. So I added a helper function
and it splits the path and remove `/` from the path.
the function:
```
const splitPath = path => {
    // remove query string
    let result = path.split('?')[0]
    // remove redundant / from the end of path
    if (result.charAt(result.length - 1) === '/') {
      result = result.slice(0, -1)
    }
    return result
}
```
new `if` condition:
```
if (!login || ctx.route.path === login.split('?')[0]) {
      ctx.app.$auth.redirect('home')
}
```