### PR TITLE
remove default auth0 audience

### DIFF
--- a/docs/providers/auth0.md
+++ b/docs/providers/auth0.md
@@ -11,7 +11,8 @@ auth: {
   strategies: {
     auth0: {
       domain: 'domain.auth0.com',
-      client_id: '....'
+      client_id: '....',
+      audience: 'https://mydomain.com/'
     }
   }
 }
@@ -30,8 +31,12 @@ User will be redirected to a page like this:
 
 💁 This provider is based on [oauth2 scheme](../schemes/oauth2.md) and supports all scheme options.
 
-### Obtaining `client_id` and **`domain`**
+### Obtaining `client_id`, **`domain`**, and `audience`
 
-This options are **REQUIRED**. Your application needs some details about this client to communicate with Auth0. You can get these details from the Settings section for your client in the [Auth0 dashboard](https://manage.auth0.com).
+`client_id` and `domain` are **REQUIRED**. Your application needs some details about this client to communicate with Auth0.
+
+`audience` is required _unless_ you've explicitly set a default audience [on your Auth0 tenent](https://manage.auth0.com/#/tenant).
+
+You can get your `client_id` and `domain` the Settings section for your client in the [Auth0 API dashboard](https://manage.auth0.com/#/applications). Your audience is defined on your [client's API](https://manage.auth0.com/#/apis).
 
 <img align="center" src="https://cdn2.auth0.com/docs/media/articles/dashboard/client_settings.png">

--- a/lib/providers/auth0.js
+++ b/lib/providers/auth0.js
@@ -6,6 +6,5 @@ module.exports = function auth0 (strategy) {
     authorization_endpoint: `https://${strategy.domain}/authorize`,
     userinfo_endpoint: `https://${strategy.domain}/userinfo`,
     scope: ['openid', 'profile', 'email'],
-    audience: strategy.domain
-  })
-}
+  });
+};

--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -70,8 +70,11 @@ export default class Oauth2Scheme {
       client_id: this.options.client_id,
       redirect_uri: this._redirectURI,
       scope: this._scope,
-      audience: this.options.audience,
-      state: randomString()
+      state: randomString(),
+    };
+
+    if (this.options.audience) {
+      opts.audience = this.options.audience;
     }
 
     this.$auth.$storage.setLocalStorage(this.name + '.state', opts.state)


### PR DESCRIPTION
As of June 8th, the `jwt-bearer` grant isn't available to new applications. Therefore, any new app cannot get a token without a specified audience ([#176](https://github.com/nuxt-community/auth-module/issues/176). This is a breaking change from upstream.

When provided, the audience *must* match the API's audience. However, audience can be omitted if a default audience is specified in the tenent's settings. https://auth0.com/docs/tokens/id-token#validate-the-claims