### PR TITLE
Fix wrong loggedIn state

### DIFF
--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -215,12 +215,10 @@ export default class Auth {
   // LoggedIn helpers
   // ---------------------------------------------------------------
   get loggedIn () {
-    console.debug('get loggedIn', this.$state.loggedIn)
     return this.$state.loggedIn
   }
 
   setLoggedIn (isLoggedIn) {
-    console.debug('set loggedIn', isLoggedIn)
     this.$storage.setState('loggedIn', isLoggedIn)
   }
 

--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -155,6 +155,7 @@ export default class Auth {
   reset () {
     if (!this.strategy.reset) {
       this.setUser(false)
+      this.setLoggedIn(false)
       this.setToken(this.$state.strategy, false)
       this.setRefreshToken(this.$state.strategy, false)
       return Promise.resolve()
@@ -211,15 +212,24 @@ export default class Auth {
   }
 
   // ---------------------------------------------------------------
+  // LoggedIn helpers
+  // ---------------------------------------------------------------
+  get loggedIn () {
+    console.debug('get loggedIn', this.$state.loggedIn)
+    return this.$state.loggedIn
+  }
+
+  setLoggedIn (isLoggedIn) {
+    console.debug('set loggedIn', isLoggedIn)
+    this.$storage.setState('loggedIn', isLoggedIn)
+  }
+
+  // ---------------------------------------------------------------
   // User helpers
   // ---------------------------------------------------------------
 
   get user () {
     return this.$state.user
-  }
-
-  get loggedIn () {
-    return this.$state.loggedIn
   }
 
   fetchUserOnce () {
@@ -230,7 +240,6 @@ export default class Auth {
   }
 
   setUser (user) {
-    this.$storage.setState('loggedIn', Boolean(user))
     this.$storage.setState('user', user)
   }
 

--- a/lib/schemes/local.js
+++ b/lib/schemes/local.js
@@ -23,7 +23,17 @@ export default class LocalScheme {
   mounted () {
     if (this.options.tokenRequired) {
       const token = this.$auth.syncToken(this.name)
-      this._setToken(token)
+
+      if (token) {
+        // Set logged in status
+        this.$auth.setLoggedIn(true)
+  
+        // Set axios token
+        this._setToken(token)
+      }
+    } else {
+      // Set logged in status
+      this.$auth.setLoggedIn(true)
     }
 
     return this.$auth.fetchUserOnce()

--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -35,8 +35,12 @@ export default class Oauth2Scheme {
   async mounted () {
     // Sync token
     const token = this.$auth.syncToken(this.name)
-    // Set axios token
+
     if (token) {
+      // Set logged in status
+      this.$auth.setLoggedIn(true)
+
+      // Set axios token
       this._setToken(token)
     }
 


### PR DESCRIPTION
Hey!

This PR fix the inconsistent state of `loggedIn` in case of `user: false` option.

It basically extract a `loggedIn` setter method to improve concept separation between user data and login state.

Alex