### PR TITLE
Changed redirect.user option name to redirect.home

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -10,8 +10,8 @@ Default:
 redirect: {
   login: '/login',
   logout: '/',
-  callback: '/login',
-  home: '/'
+  home: '/',
+  callback: '/login'
 }
 ```
 


### PR DESCRIPTION
Hello,

I can't find any documentation about the `redirect.user` option, I assume the name is meant to be `redirect.home`.  

This should match the defaults defined in: https://github.com/nuxt-community/auth-module/blob/a8fbda82587acf3e8e5c524c7a49bae2f4ad28db/lib/module/defaults.js#L18-L23

😄