### PR TITLE
Add configurable refresh token on local scheme

### DIFF
--- a/lib/schemes/local.js
+++ b/lib/schemes/local.js
@@ -34,6 +34,13 @@ export default class LocalScheme {
       return
     }
 
+    const accessTokenKey = this.options.accessTokenKey
+      ? this.options.accessTokenKey
+      : 'access_token'
+    const refreshTokenKey = this.options.refreshTokenKey
+      ? this.options.refreshTokenKey
+      : 'refresh_token'
+
     // Ditch any leftover local tokens before attempting to log in
     await this._logoutLocally()
 
@@ -44,11 +51,20 @@ export default class LocalScheme {
 
     if (this.options.tokenRequired) {
       const token = this.options.tokenType
-        ? this.options.tokenType + ' ' + result
-        : result
+        ? this.options.tokenType + ' ' + result[accessTokenKey]
+        : result[accessTokenKey]
 
       this.$auth.setToken(this.name, token)
       this._setToken(token)
+
+      // Check if we are utilising refresh tokens and store if necessary
+      if (this.options.refreshToken) {
+        const refreshToken = this.options.tokenType
+          ? this.options.tokenType + ' ' + result[refreshTokenKey]
+          : result[refreshTokenKey]
+
+        this.$auth.setRefreshToken(this.name, refreshToken)
+      }
     }
 
     return this.fetchUser()
@@ -100,5 +116,8 @@ const DEFAULTS = {
   tokenRequired: true,
   tokenType: 'Bearer',
   globalToken: true,
+  refreshToken: false,
+  refreshTokenKey: 'refresh_token',
+  accessTokenKey: 'access_token',
   tokenName: 'Authorization'
 }


### PR DESCRIPTION
This pull request adds refresh functionality to the local scheme, configurable in config.

This change would require that responses be a JSON object rather than a string value.