### PR TITLE
feat(middleware): add guest option in auth middleware

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -27,4 +27,12 @@ export default {
 }
 ```
 
+You can set `auth` option to `guest` in a specific component. When this middleware is enabled on a route and `loggedIn` is `true` user will be redirected to `redirect.home` route. (`/` by default)
+
+```js
+export default {
+  auth: 'guest'
+}
+```
+
 👉 Now you have to configure some [Strategies](schemes/README.md) for auth.

--- a/lib/core/middleware.js
+++ b/lib/core/middleware.js
@@ -19,7 +19,8 @@ Middleware.auth = function (ctx) {
   if (ctx.app.$auth.$state.loggedIn) {
     // -- Authorized --
     // Redirect to home page if inside login page (or login page disabled)
-    if (!login || normalizePath(ctx.route.path) === normalizePath(login)) {
+    // or if options: { auth: 'guest' } is set on the route
+    if (!login || normalizePath(ctx.route.path) === normalizePath(login) || routeOption(ctx.route, 'auth', 'guest')) {
       ctx.app.$auth.redirect('home')
     }
   } else {

--- a/lib/core/middleware.js
+++ b/lib/core/middleware.js
@@ -18,8 +18,10 @@ Middleware.auth = function (ctx) {
 
   if (ctx.app.$auth.$state.loggedIn) {
     // -- Authorized --
-    // Redirect to home page if inside login page (or login page disabled)
-    // or if options: { auth: 'guest' } is set on the route
+    // Redirect to home page if:
+    // - inside login page
+    // - login page disabled
+    // - options: { auth: 'guest' } is set on the page
     if (!login || normalizePath(ctx.route.path) === normalizePath(login) || routeOption(ctx.route, 'auth', 'guest')) {
       ctx.app.$auth.redirect('home')
     }


### PR DESCRIPTION
In most cases you need to create `guest` middleware:

```js
// middleware/guest.js
export default function({ store, redirect }) {
    if (store.state.auth.loggedIn) {
        return redirect('/');
    }
}
```

With this feature I can simply add an option:

> No need to create a new middleware.

```html
// pages/guest.vue
<template>
  <div>guest</div>
</tempalte>

<script>
export default {
  middleware: ['auth'],
  options: {
    auth: 'guest'
  }
}
</script>
```