### PR TITLE
Remove tokenType from token and tokenType added to axios headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="4.6.0"></a>
+# [4.6.0](https://github.com/nuxt-community/auth-module/compare/v4.5.1...v4.6.0) (2018-11-28)
+
+
+### Bug Fixes
+
+* **api/auth.md:** typo([#204](https://github.com/nuxt-community/auth-module/issues/204)) ([f0e693a](https://github.com/nuxt-community/auth-module/commit/f0e693a))
+* randomString btoa fallback for SSR ([#230](https://github.com/nuxt-community/auth-module/issues/230)) ([604cc5d](https://github.com/nuxt-community/auth-module/commit/604cc5d))
+* **auth:** handle mounted errors during init ([#234](https://github.com/nuxt-community/auth-module/issues/234)) ([03dba23](https://github.com/nuxt-community/auth-module/commit/03dba23))
+* **docs:** GitHub capitalize ([#246](https://github.com/nuxt-community/auth-module/issues/246)) ([eb7dc9e](https://github.com/nuxt-community/auth-module/commit/eb7dc9e))
+* **docs:** minor proper english revisions ([#200](https://github.com/nuxt-community/auth-module/issues/200)) ([619184b](https://github.com/nuxt-community/auth-module/commit/619184b))
+* **docs:** spelling fix ([#247](https://github.com/nuxt-community/auth-module/issues/247)) ([c2b0d7b](https://github.com/nuxt-community/auth-module/commit/c2b0d7b))
+* **docs:** typo ([#203](https://github.com/nuxt-community/auth-module/issues/203)) ([3a0e080](https://github.com/nuxt-community/auth-module/commit/3a0e080))
+* **docs:** typo [#224](https://github.com/nuxt-community/auth-module/issues/224)  ([752f4ad](https://github.com/nuxt-community/auth-module/commit/752f4ad))
+* remove default auth0 audience ([#239](https://github.com/nuxt-community/auth-module/issues/239)) ([abfa084](https://github.com/nuxt-community/auth-module/commit/abfa084))
+* set extended for body-parser urlencoded to prevent the deprecation warning ([#199](https://github.com/nuxt-community/auth-module/issues/199)) ([0226836](https://github.com/nuxt-community/auth-module/commit/0226836))
+* **docs:** update glassory read more title ([a53c38c](https://github.com/nuxt-community/auth-module/commit/a53c38c))
+* **middleware:** remove trailing slash from redirect paths ([#235](https://github.com/nuxt-community/auth-module/issues/235)) ([398a515](https://github.com/nuxt-community/auth-module/commit/398a515))
+* **oauth2, auth0:** add audience to requests ([#222](https://github.com/nuxt-community/auth-module/issues/222)) ([174e135](https://github.com/nuxt-community/auth-module/commit/174e135))
+* **storage.md:** fix typo ([a8fbda8](https://github.com/nuxt-community/auth-module/commit/a8fbda8))
+
+
+### Features
+
+* add resetOnError ([#197](https://github.com/nuxt-community/auth-module/issues/197)) ([469f2f8](https://github.com/nuxt-community/auth-module/commit/469f2f8))
+
+
+
 <a name="4.5.1"></a>
 ## [4.5.1](https://github.com/nuxt-community/auth-module/compare/v4.5.0...v4.5.1) (2018-05-21)
 

--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -22,44 +22,47 @@ export default class Auth {
     this.$state = storage.state
   }
 
-  async init () {
-    // Reset on error
-    if (this.options.resetOnError) {
-      this.onError((...args) => {
-        if (typeof (this.options.resetOnError) !== 'function' || this.options.resetOnError(...args)) {
-          this.reset()
-        }
-      })
-    }
-
-    // Restore strategy
-    this.$storage.syncUniversal('strategy', this.options.defaultStrategy)
-
-    // Set default strategy if current one is invalid
-    if (!this.strategy) {
-      this.$storage.setUniversal('strategy', this.options.defaultStrategy)
-
-      // Give up if still invalid
-      if (!this.strategy) {
-        return Promise.resolve()
-      }
-    }
-    
-    try {
-      // Call mounted for active strategy on initial load
-      await this.mounted()
-    } catch (error) {
-      this.callOnError(error)
-    } finally {
-      // Watch for loggedIn changes only in client side
-      if (process.client && this.options.watchLoggedIn) {
-        this.$storage.watchState('loggedIn', loggedIn => {
-          if (!routeOption(this.ctx.route, 'auth', false)) {
-            this.redirect(loggedIn ? 'home' : 'logout')
+  init () {
+    return new Promise(async (resolve, reject) => {
+      // Reset on error
+      if (this.options.resetOnError) {
+        this.onError((...args) => {
+          if (typeof (this.options.resetOnError) !== 'function' || this.options.resetOnError(...args)) {
+            this.reset()
           }
         })
       }
-    }
+
+      // Restore strategy
+      this.$storage.syncUniversal('strategy', this.options.defaultStrategy)
+
+      // Set default strategy if current one is invalid
+      if (!this.strategy) {
+        this.$storage.setUniversal('strategy', this.options.defaultStrategy)
+
+        // Give up if still invalid
+        if (!this.strategy) {
+          return Promise.resolve()
+        }
+      }
+      
+      try {
+        // Call mounted for active strategy on initial load
+        await this.mounted()
+      } catch (error) {
+        this.callOnError(error)
+      } finally {
+        // Watch for loggedIn changes only in client side
+        if (process.client && this.options.watchLoggedIn) {
+          this.$storage.watchState('loggedIn', loggedIn => {
+            if (!routeOption(this.ctx.route, 'auth', false)) {
+              this.redirect(loggedIn ? 'home' : 'logout')
+            }
+          })
+        }
+        resolve()
+      }
+    })
   }
 
   // Backward compatibility

--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -175,13 +175,13 @@ export default class Auth {
   // ---------------------------------------------------------------
 
   getToken (strategy) {
-    const _key = this.options.token.prefix + strategy
+    const _key = this.options.token.prefix + (strategy || this.$state.strategy)
 
     return this.$storage.getUniversal(_key)
   }
 
   setToken (strategy, token) {
-    const _key = this.options.token.prefix + strategy
+    const _key = this.options.token.prefix + (strategy || this.$state.strategy)
 
     return this.$storage.setUniversal(_key, token)
   }
@@ -279,7 +279,8 @@ export default class Auth {
       _endpoint.headers = {}
     }
     if (!_endpoint.headers['Authorization'] && isSet(token) && token) {
-      _endpoint.headers['Authorization'] = token
+      const tokenType = this.strategies[this.$state.strategy].options.tokenType
+      _endpoint.headers['Authorization'] = tokenType ? tokenType + ' ' + token : token
     }
 
     return this.request(_endpoint)

--- a/lib/schemes/local.js
+++ b/lib/schemes/local.js
@@ -9,7 +9,8 @@ export default class LocalScheme {
   _setToken (token) {
     if (this.options.globalToken) {
       // Set Authorization token for all axios requests
-      this.$auth.ctx.app.$axios.setHeader(this.options.tokenName, token)
+      const _token = this.options.tokenType ? this.options.tokenType + ' ' + token : token
+      this.$auth.ctx.app.$axios.setHeader(this.options.tokenName, _token)
     }
   }
 
@@ -37,16 +38,12 @@ export default class LocalScheme {
     // Ditch any leftover local tokens before attempting to log in
     await this._logoutLocally()
 
-    const result = await this.$auth.request(
+    const token = await this.$auth.request(
       endpoint,
       this.options.endpoints.login
     )
 
     if (this.options.tokenRequired) {
-      const token = this.options.tokenType
-        ? this.options.tokenType + ' ' + result
-        : result
-
       this.$auth.setToken(this.name, token)
       this._setToken(token)
     }

--- a/package.json
+++ b/package.json
@@ -61,5 +61,20 @@
     "nuxt-edge": "^2.0.0-25582697.225",
     "puppeteer": "^1.7.0",
     "standard-version": "^4.4.0"
-  }
+  },
+  "bugs": {
+    "url": "https://github.com/hilkbahar/auth-module/issues"
+  },
+  "homepage": "https://github.com/hilkbahar/auth-module#readme",
+  "directories": {
+    "doc": "docs",
+    "example": "examples",
+    "lib": "lib",
+    "test": "test"
+  },
+  "keywords": [
+    "nuxtjs",
+    "auth-module",
+    "nuxt-auth"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxtjs/auth",
-  "version": "4.5.1",
+  "version": "4.6.0",
   "description": "Authentication module for Nuxt.js",
   "license": "MIT",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,26 +1,14 @@
 {
-  "name": "@nuxtjs/auth",
-  "version": "4.6.0",
+  "name": "@blupoint/nuxt-auth-module",
+  "version": "0.0.1",
   "description": "Authentication module for Nuxt.js",
   "license": "MIT",
-  "contributors": [
-    {
-      "name": "Pooya Parsa <pooya@pi0.ir>",
-      "url": "https://github.com/pi0"
-    },
-    {
-      "name": "Herberts Cruz <herbertscruz@gmail.com>"
-    },
-    {
-      "name": "Tony Briet",
-      "url": "https://github.com/breakingrobot"
-    }
-  ],
   "main": "lib/module/index.js",
-  "repository": "https://github.com/nuxt-community/auth-module",
-  "publishConfig": {
-    "access": "public"
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hilkbahar/auth-module.git"
   },
+  "author": "@hilkbahar",
   "scripts": {
     "heroku-postbuild": "nuxt build examples/demo",
     "start": "nuxt start examples/demo",


### PR DESCRIPTION
Bearer {token} is an authorization type not a token. Auth module setToken method without Bearer key as default. But it requires Bearer string before token key when setting token to axios. Therefore I removed the Bearer string when getting token to match the default behaviour.