### PR TITLE
feat(local): reduce api requisition, if user property exists inside login response

### DIFF
--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -44,7 +44,7 @@ export default class Auth {
         return Promise.resolve()
       }
     }
-    
+
     try {
       // Call mounted for active strategy on initial load
       await this.mounted()
@@ -254,13 +254,7 @@ export default class Auth {
 
     return this.ctx.app.$axios
       .request(_endpoint)
-      .then(response => {
-        if (_endpoint.propertyName) {
-          return getProp(response.data, _endpoint.propertyName)
-        } else {
-          return response.data
-        }
-      })
+      .then(response => response.data)
       .catch(error => {
         // Call all error handlers
         this.callOnError(error, { method: 'request' })

--- a/lib/schemes/local.js
+++ b/lib/schemes/local.js
@@ -1,3 +1,5 @@
+import getProp from 'dotprop'
+
 export default class LocalScheme {
   constructor (auth, options) {
     this.$auth = auth
@@ -42,16 +44,27 @@ export default class LocalScheme {
       this.options.endpoints.login
     )
 
+    const tokenValue = getProp(result, this.options.endpoints.login.propertyName) || result
+
     if (this.options.tokenRequired) {
       const token = this.options.tokenType
-        ? this.options.tokenType + ' ' + result
-        : result
+        ? this.options.tokenType + ' ' + tokenValue
+        : tokenValue
 
       this.$auth.setToken(this.name, token)
       this._setToken(token)
     }
 
-    return this.fetchUser()
+    if (!this.options.endpoints.user) {
+      return this.fetchUser()
+    }
+
+    const user = getProp(result, this.options.endpoints.user.propertyName)
+    if (!user) {
+      return this.fetchUser()
+    }
+
+    this.$auth.setUser(user)
   }
 
   async fetchUser (endpoint) {
@@ -72,7 +85,7 @@ export default class LocalScheme {
       endpoint,
       this.options.endpoints.user
     )
-    this.$auth.setUser(user)
+    this.$auth.setUser(getProp(user, this.options.endpoints.user.propertyName) || user)
   }
 
   async logout (endpoint) {


### PR DESCRIPTION
**Problem:**

Using the `local` strategy, the `login` method calls api to log in and `fetchUser`, this causes two calls in the API, which in many cases is not a good practice.

```js
this.$auth.login()
// /api/auth/login - response token
// /api/auth/user - response user
```

**Solution:**

With these improvements we can return the token and the user in a single login request, reducing the calls in the api.

```js
this.$auth.login()
// /api/auth/login - response token and user
```

**Important:**
This does not break anything, because if the user property does not exist in the login request, auth will continue making two requests.