### PR TITLE
refactor: replace deprecated `process.browser` with `process.client`

### DIFF
--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -44,7 +44,7 @@ export default class Auth {
         return Promise.resolve()
       }
     }
-    
+
     try {
       // Call mounted for active strategy on initial load
       await this.mounted()
@@ -344,7 +344,7 @@ export default class Auth {
       return
     }
 
-    if (process.browser) {
+    if (process.client) {
       if (noRouter) {
         window.location.replace(to)
       } else {

--- a/lib/core/storage.js
+++ b/lib/core/storage.js
@@ -192,7 +192,7 @@ export default class Storage {
 
     const _key = this.options.cookie.prefix + key
 
-    const cookieStr = process.browser
+    const cookieStr = process.client
       ? document.cookie
       : this.ctx.req.headers.cookie
 

--- a/lib/core/utilities.js
+++ b/lib/core/utilities.js
@@ -25,12 +25,12 @@ export const encodeQuery = queryObject => {
     .join('&')
 }
 
-export const randomString = () => (process.browser ? btoa(Math.random() + '') : Buffer.from(Math.random() + '').toString('base64')).replace('==', '')
+export const randomString = () => (process.client ? btoa(Math.random() + '') : Buffer.from(Math.random() + '').toString('base64')).replace('==', '')
 
 export const routeOption = (route, key, value) => {
   return route.matched.some(m => {
-    if (process.browser) {
-      // Browser
+    if (process.client) {
+      // Client
       return Object.values(m.components).some(
         component => component.options && component.options[key] === value
       )

--- a/lib/module/plugin.js
+++ b/lib/module/plugin.js
@@ -28,7 +28,7 @@ export default function (ctx, inject) {
 
   // Initialize auth
   return $auth.init().catch(error => {
-    if (process.browser) {
+    if (process.client) {
       console.error('[ERROR] [AUTH]', error)
     }
   })

--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -27,7 +27,7 @@ export default class Oauth2Scheme {
       return url
     }
 
-    if (process.browser) {
+    if (process.client) {
       return window.location.origin + this.$auth.options.redirect.callback
     }
   }


### PR DESCRIPTION
Currently the auth-module is throwing `process.browser is deprecated, use process.client instead.` warnings. This pull request replaces all `process.browser` instances with `process.client`.

https://github.com/nuxt/nuxt.js/issues/4106