### PR TITLE
setUserToken

### DIFF
--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -63,6 +63,19 @@ this.$auth.login(/* .... */)
   .then(() => this.$toast.success('Logged In!'))
 ```
 
+### `setUserToken(token)`
+
+- Returns: `Promise`
+
+Set the auth token and fetch the user using the new token and current strategy. 
+
+> **TIP:** This function can properly set the user after registration
+
+```js
+this.$auth.setUserToken(token)
+  .then(() => this.$toast.success('User set!'))
+```
+
 ## `logout()`
 
 - Returns: `Promise`

--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -44,7 +44,7 @@ export default class Auth {
         return Promise.resolve()
       }
     }
-    
+
     try {
       // Call mounted for active strategy on initial load
       await this.mounted()
@@ -152,6 +152,13 @@ export default class Auth {
 
     return Promise.resolve(this.strategy.logout(...arguments)).catch(error => {
       this.callOnError(error, { method: 'logout' })
+      return Promise.reject(error)
+    })
+  }
+
+  setUserToken (token) {
+    return Promise.resolve(this.strategy.setUserToken(token)).catch(error => {
+      this.callOnError(error, { method: 'setUserToken' })
       return Promise.reject(error)
     })
   }

--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -157,6 +157,11 @@ export default class Auth {
   }
 
   setUserToken (token) {
+    if (!this.strategy.setUserToken) {
+      this.setToken(this.strategy.name, token)
+      return Promise.resolve()
+    }
+
     return Promise.resolve(this.strategy.setUserToken(token)).catch(error => {
       this.callOnError(error, { method: 'setUserToken' })
       return Promise.reject(error)

--- a/lib/schemes/local.js
+++ b/lib/schemes/local.js
@@ -54,6 +54,22 @@ export default class LocalScheme {
     return this.fetchUser()
   }
 
+  async setUserToken (tokenValue) {
+    // Ditch any leftover local tokens before attempting to log in
+    await this._logoutLocally()
+
+    if (this.options.tokenRequired) {
+      const token = this.options.tokenType
+        ? this.options.tokenType + ' ' + tokenValue
+        : tokenValue
+
+      this.$auth.setToken(this.name, token)
+      this._setToken(token)
+    }
+
+    return this.fetchUser()
+  }
+
   async fetchUser (endpoint) {
     // User endpoint is disabled.
     if (!this.options.endpoints.user) {


### PR DESCRIPTION
After registration and reseting a password, my api returns an auth token and which I would like to use to set the current user.

To do this currently, I was using code that looks like this:
``` js
const token = `Bearer ${data.access_token}`

this.$auth.setToken(this.$store.state.auth.strategy, token)
this.$auth.strategy._setToken(token)
return this.$auth.fetchUser()
```

I believe this is a common use case, so this pr adds a function `$auth.setUserToken(token)` to correctly set the user with an auth code. The function `setToken` does not set the Authorization header, so it doesn't handle this use case very well.

Thanks!