### PR TITLE
perf(cookie): use hardtack instead of js-cookie

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -18,7 +18,7 @@ redirect: {
 * `login`: User will be redirected to this path if *login is required*.
 * `logout`: User will be redirected to this path if *after logout, current route is protected*.
 * `home`: User will be redirect to this path *after login*. (`rewriteRedirects` will rewrite this path)
-* `callback`: User will be redirect to this path by the identity provider *after login*. (Should match configured `Allowed Callback URLs` (or similar setting) in your app/client with the identity provider) 
+* `callback`: User will be redirect to this path by the identity provider *after login*. (Should match configured `Allowed Callback URLs` (or similar setting) in your app/client with the identity provider)
 
 Each redirect path can be disabled by setting to `false`.
 Also you can disable all redirects by setting `redirect` to `false`
@@ -77,9 +77,9 @@ cookie: {
 ```
 
 * **prefix** - Default token prefix used in building a key for token storage in the browser's localStorage.
-* **options** - Additional cookie options, passed to [js-cookie](https://github.com/js-cookie/js-cookie) `set` and `get` functions. See full details on options they support and their defaults [here](https://github.com/js-cookie/js-cookie#cookie-attributes), which includes:
+* **options** - Additional cookie options, passed to [hardtack](https://github.com/alik0211/hardtack) `set` and `get` functions. See full details on options they support and their defaults [here](https://github.com/alik0211/hardtack#setname-string-value-string-options), which includes:
   * `path` - path where the cookie is visible. Default is '/'.
-  * `expires` - can be used to specify cookie lifetime in `Number` of days or specific `Date`. Default is session only.
+  * `expires` - Date in GMT format. See [Date.toUTCString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toUTCString) for help formatting this value.
   * `domain` - domain (and by extension subdomain/s) where the cookie is visible. Default is domain and all subdomains.
   * `secure` - sets whether the cookie requires a secure protocol (https). Default is false, **should be set to true if possible**.
 

--- a/lib/core/storage.js
+++ b/lib/core/storage.js
@@ -1,5 +1,5 @@
 import Vue from 'vue'
-import Cookies from 'js-cookie'
+import hardtack from 'hardtack'
 import getProp from 'dotprop'
 import { parse as parseCookie } from 'cookie'
 
@@ -177,9 +177,9 @@ export default class Storage {
     const _options = Object.assign({}, this.options.cookie.options, options)
 
     if (isUnset(value)) {
-      Cookies.remove(_key, _options)
+      hardtack.remove(_key, _options)
     } else {
-      Cookies.set(_key, value, _options)
+      hardtack.set(_key, value, _options)
     }
 
     return value

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "consola": "^1.3.0",
     "cookie": "^0.3.1",
     "dotprop": "^1.0.2",
-    "js-cookie": "^2.2.0",
+    "hardtack": "^2.1.0",
     "lodash": "^4.17.10"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3451,6 +3451,11 @@ har-validator@~5.0.3:
     ajv "^5.1.0"
     har-schema "^2.0.0"
 
+hardtack@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/hardtack/-/hardtack-2.1.0.tgz#621c92ae7ad4dc342e55ad274ddf703469e8dcba"
+  integrity sha512-J7RkzZnxPyTJSmlknFHISXAgwL0MgJMEFHrRGsdw8bIGbNsJ6FCKHg+ho4BVH7YUd9KGguI5XYFADkutN4W+MQ==
+
 has-ansi@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
@@ -4448,10 +4453,6 @@ jest@^22.4.4:
 js-base64@^2.1.9:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.3.tgz#2e545ec2b0f2957f41356510205214e98fad6582"
-
-js-cookie@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.0.tgz#1b2c279a6eece380a12168b92485265b35b1effb"
 
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
hardtack easier js-cookie on 60%
https://cdn.jsdelivr.net/npm/js-cookie@2/src/js.cookie.min.js gzipped - **1105 bytes**
https://cdn.jsdelivr.net/npm/hardtack@2.1.0/dist/hardtack.min.js gzipped - **431 bytes**