### PR TITLE
Remove default propertyName

### DIFF
--- a/lib/module/defaults.js
+++ b/lib/module/defaults.js
@@ -64,8 +64,7 @@ module.exports = {
       endpoints: {
         login: {
           url: '/api/auth/login',
-          method: 'post',
-          propertyName: 'token'
+          method: 'post'
         },
         logout: {
           url: '/api/auth/logout',
@@ -73,8 +72,7 @@ module.exports = {
         },
         user: {
           url: '/api/auth/user',
-          method: 'get',
-          propertyName: 'user'
+          method: 'get'
         }
       }
     }


### PR DESCRIPTION
You can not override propertyName with undefined if the module provides a default value.

> propertyName can be used to specify which field of the response JSON to be used for value. **It can be **undefined** to directly use API response** or being more complicated like auth.user.

This is what the documentation says. But at the moment it is not possible to actually do it. 