### PR TITLE
Option to set auth header name

### DIFF
--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -7,6 +7,8 @@ export default class Auth {
   constructor (ctx, options) {
     this.ctx = ctx
     this.options = options
+    
+    this.authHeaderName = options.authHeader || 'Authorization';
 
     // Strategies
     this.strategies = {}
@@ -265,8 +267,8 @@ export default class Auth {
     if (!_endpoint.headers) {
       _endpoint.headers = {}
     }
-    if (!_endpoint.headers['Authorization'] && isSet(token) && token) {
-      _endpoint.headers['Authorization'] = token
+    if (!_endpoint.headers[this.authHeaderName] && isSet(token) && token) {
+      _endpoint.headers[this.authHeaderName] = token
     }
 
     return this.request(_endpoint)


### PR DESCRIPTION
There are some scenarios, mostly due to some specific business logic, when one need to customize auth headers. Currently there is no possibility to do this. This patch adds a possibility to set header name via option