### PR TITLE
feat(oauth2): support `access_type=offline` to enable refresh tokens from google

### DIFF
--- a/docs/schemes/oauth2.md
+++ b/docs/schemes/oauth2.md
@@ -14,7 +14,7 @@ auth: {
       authorization_endpoint: 'https://accounts.google.com/o/oauth2/auth',
       userinfo_endpoint: 'https://www.googleapis.com/oauth2/v3/userinfo',
       scope: ['openid', 'profile', 'email'],
-      access_type: 'online',
+      access_type: undefined,
       response_type: 'token',
       token_type: 'Bearer',
       redirect_uri: undefined,

--- a/docs/schemes/oauth2.md
+++ b/docs/schemes/oauth2.md
@@ -14,6 +14,7 @@ auth: {
       authorization_endpoint: 'https://accounts.google.com/o/oauth2/auth',
       userinfo_endpoint: 'https://www.googleapis.com/oauth2/v3/userinfo',
       scope: ['openid', 'profile', 'email'],
+      access_type: 'online',
       response_type: 'token',
       token_type: 'Bearer',
       redirect_uri: undefined,
@@ -41,6 +42,14 @@ If a `false` value is set, we only do login without fetching user profile.
 ### `response_type`
 
 By default is `token`. If you use `code` you may have to implement a server side logic to sign the response code.
+
+### `access_type`
+
+By default is `online`. Set to `offline` if using Google code authorization flow (`response_type: 'code'`) to ensure a refresh token is returned in the initial login request. (See [Google documentation](https://developers.google.com/identity/protocols/OpenIDConnect#refresh-tokens))
+
+### `access_token_endpoint`
+
+If using `response_type: 'code'` provide a URI for a service that accepts a POST request with JSON payload containing a `code` property, and returns tokens [exchanged by provider](https://developers.google.com/identity/protocols/OpenIDConnect#exchangecode) for `code`. See [source code](https://github.com/nuxt-community/auth-module/blob/6420ddca32f3190e1100d1e04502a2bb48339b5c/lib/schemes/oauth2.js#L124)
 
 ### `token_type`
 

--- a/docs/schemes/oauth2.md
+++ b/docs/schemes/oauth2.md
@@ -49,7 +49,7 @@ By default is `online`. Set to `offline` if using Google code authorization flow
 
 ### `access_token_endpoint`
 
-If using `response_type: 'code'` provide a URI for a service that accepts a POST request with JSON payload containing a `code` property, and returns tokens [exchanged by provider](https://developers.google.com/identity/protocols/OpenIDConnect#exchangecode) for `code`. See [source code](https://github.com/nuxt-community/auth-module/blob/6420ddca32f3190e1100d1e04502a2bb48339b5c/lib/schemes/oauth2.js#L124)
+If using `response_type: 'code'` provide a URI for a service that accepts a POST request with JSON payload containing a `code` property, and returns tokens [exchanged by provider](https://developers.google.com/identity/protocols/OpenIDConnect#exchangecode) for `code`. See [source code](https://github.com/nuxt-community/auth-module/blob/dev/lib/schemes/oauth2.js)
 
 ### `token_type`
 

--- a/docs/schemes/oauth2.md
+++ b/docs/schemes/oauth2.md
@@ -15,6 +15,7 @@ auth: {
       userinfo_endpoint: 'https://www.googleapis.com/oauth2/v3/userinfo',
       scope: ['openid', 'profile', 'email'],
       access_type: undefined,
+      access_token_endpoint: undefined,
       response_type: 'token',
       token_type: 'Bearer',
       redirect_uri: undefined,
@@ -45,11 +46,11 @@ By default is `token`. If you use `code` you may have to implement a server side
 
 ### `access_type`
 
-By default is `online`. Set to `offline` if using Google code authorization flow (`response_type: 'code'`) to ensure a refresh token is returned in the initial login request. (See [Google documentation](https://developers.google.com/identity/protocols/OpenIDConnect#refresh-tokens))
+If using Google code authorization flow (`response_type: 'code'`) set to `offline` to ensure a refresh token is returned in the initial login request. (See [Google documentation](https://developers.google.com/identity/protocols/OpenIDConnect#refresh-tokens))
 
 ### `access_token_endpoint`
 
-If using `response_type: 'code'` provide a URI for a service that accepts a POST request with JSON payload containing a `code` property, and returns tokens [exchanged by provider](https://developers.google.com/identity/protocols/OpenIDConnect#exchangecode) for `code`. See [source code](https://github.com/nuxt-community/auth-module/blob/dev/lib/schemes/oauth2.js)
+If using Google code authorization flow (`response_type: 'code'`) provide a URI for a service that accepts a POST request with JSON payload containing a `code` property, and returns tokens [exchanged by provider](https://developers.google.com/identity/protocols/OpenIDConnect#exchangecode) for `code`. See [source code](https://github.com/nuxt-community/auth-module/blob/dev/lib/schemes/oauth2.js)
 
 ### `token_type`
 

--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -3,6 +3,7 @@ import { encodeQuery, parseQuery, randomString } from '../utilities'
 const DEFAULTS = {
   token_type: 'Bearer',
   response_type: 'token',
+  access_type: 'online',
   tokenName: 'Authorization'
 }
 
@@ -67,6 +68,7 @@ export default class Oauth2Scheme {
     const opts = {
       protocol: 'oauth2',
       response_type: this.options.response_type,
+      access_type: this.options.access_type,
       client_id: this.options.client_id,
       redirect_uri: this._redirectURI,
       scope: this._scope,

--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -3,6 +3,7 @@ import { encodeQuery, parseQuery, randomString } from '../utilities'
 const DEFAULTS = {
   token_type: 'Bearer',
   response_type: 'token',
+  // @see: https://developers.google.com/identity/protocols/OpenIDConnect#refresh-tokens
   access_type: 'online',
   tokenName: 'Authorization'
 }

--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -3,8 +3,6 @@ import { encodeQuery, parseQuery, randomString } from '../utilities'
 const DEFAULTS = {
   token_type: 'Bearer',
   response_type: 'token',
-  // https://developers.google.com/identity/protocols/OpenIDConnect#refresh-tokens
-  access_type: 'online',
   tokenName: 'Authorization'
 }
 

--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -3,7 +3,7 @@ import { encodeQuery, parseQuery, randomString } from '../utilities'
 const DEFAULTS = {
   token_type: 'Bearer',
   response_type: 'token',
-  // @see: https://developers.google.com/identity/protocols/OpenIDConnect#refresh-tokens
+  // https://developers.google.com/identity/protocols/OpenIDConnect#refresh-tokens
   access_type: 'online',
   tokenName: 'Authorization'
 }


### PR DESCRIPTION
Added support for access_type=offline, required by Google Oauth code exchange authorization flow to get refresh token on first login.

See https://developers.google.com/identity/protocols/OpenIDConnect#refresh-tokens

I set the default value for access-type to 'online', as this is the normal case when not doing a code exchange.