### PR TITLE
allow to add a function to redirection configuration

### DIFF
--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -330,7 +330,9 @@ export default class Auth {
 
     const from = this.options.fullPathRedirect ? this.ctx.route.fullPath : this.ctx.route.path
 
-    let to = this.options.redirect[name]
+    let to = (typeof this.options.redirect[name] === 'function')
+      ? this.options.redirect[name](this.ctx) : this.options.redirect[name]
+
     if (!to) {
       return
     }

--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -324,7 +324,7 @@ export default class Auth {
   }
 
   redirect (name, noRouter = false) {
-    if (!this.options.redirect) {
+    if (!this.options.redirect || !this.options.redirect[name]) {
       return
     }
 

--- a/lib/core/middleware.js
+++ b/lib/core/middleware.js
@@ -19,7 +19,8 @@ Middleware.auth = function (ctx) {
   if (ctx.app.$auth.$state.loggedIn) {
     // -- Authorized --
     // Redirect to home page if inside login page (or login page disabled)
-    if (!login || normalizePath(ctx.route.path) === normalizePath(login)) {
+    const loginPath = typeof login === 'function' ? login(ctx) : login
+    if (!loginPath || normalizePath(ctx.route.path) === normalizePath(loginPath)) {
       ctx.app.$auth.redirect('home')
     }
   } else {
@@ -27,7 +28,8 @@ Middleware.auth = function (ctx) {
     // Redirect to login page if not authorized and not inside callback page
     // (Those passing `callback` at runtime need to mark their callback component
     // with `auth: false` to avoid an unnecessary redirect from callback to login)
-    if (!callback || normalizePath(ctx.route.path) !== normalizePath(callback)) {
+    const callbackPath = typeof callback === 'function' ? callback(ctx) : callback
+    if (!callbackPath || normalizePath(ctx.route.path) !== normalizePath(callbackPath)) {
       ctx.app.$auth.redirect('login')
     }
   }

--- a/lib/module/plugin.js
+++ b/lib/module/plugin.js
@@ -7,7 +7,7 @@ import './middleware'
 
 export default function (ctx, inject) {
   // Options
-  const options = <%= JSON.stringify(options.options) %>
+  const options = <%= serialize(options.options) %>
 
   // Create a new Auth instance
   const $auth = new Auth(ctx, options)

--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -74,8 +74,8 @@ export default class Oauth2Scheme {
       scope: this._scope,
       // Note: The primary reason for using the state parameter is to mitigate CSRF attacks.
       // @see: https://auth0.com/docs/protocols/oauth2/oauth-state
-      state: this.options.state || randomString(),
-    };
+      state: this.options.state || randomString()
+    }
 
     if (this.options.audience) {
       opts.audience = this.options.audience

--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -28,7 +28,9 @@ export default class Oauth2Scheme {
     }
 
     if (process.browser) {
-      return window.location.origin + this.$auth.options.redirect.callback
+      const callbackPath = typeof this.$auth.options.redirect.callback === 'function'
+        ? this.$auth.options.redirect.callback(this.$auth.ctx) : this.$auth.options.redirect.callback
+      return window.location.origin + callbackPath
     }
   }
 

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -5,19 +5,27 @@ const config = require('./fixtures/basic/nuxt.config')
 
 const url = path => `http://localhost:3000${path}`
 
+const initNuxt = async (config) => {
+  const instance = new Nuxt(config)
+  await new Builder(instance).build()
+  await instance.listen(process.env.PORT)
+  return instance
+}
+
+const initBrowser = async () => {
+  return puppeteer.launch({
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    executablePath: process.env.PUPPETEER_EXECUTABLE_PATH
+  })
+}
+
 describe('auth', () => {
   let nuxt
   let browser
 
   beforeAll(async () => {
-    browser = await puppeteer.launch({
-      args: ['--no-sandbox', '--disable-setuid-sandbox'],
-      executablePath: process.env.PUPPETEER_EXECUTABLE_PATH
-    })
-
-    nuxt = new Nuxt(config)
-    await new Builder(nuxt).build()
-    await nuxt.listen(process.env.PORT)
+    browser = await initBrowser()
+    nuxt = await initNuxt(config)
   }, 60000)
 
   afterAll(async () => {

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -117,3 +117,52 @@ describe('auth', () => {
     await page.close()
   })
 })
+
+describe('redirect when unauthorized', () => {
+  let browser
+
+  beforeAll(async () => { browser = await initBrowser() }, 60000)
+  afterAll(async () => { await browser.close() })
+
+  describe('redirection setting by string', () => {
+    test('should redirect to login page', async () => {
+      const redirect = { login: '/login?param=test1' }
+      const nuxt = await initNuxt({
+        ...config,
+        ...{
+          auth: { ...config.auth, ...{ redirect } }
+        }
+      })
+      const page = await browser.newPage()
+      await page.goto(url('/secure'))
+
+      const currentUri = await page.evaluate(() => window.location.href)
+
+      await page.close()
+      await nuxt.close()
+
+      expect(currentUri).toBe(url('/login?param=test1'))
+    }, 60000)
+  })
+
+  describe('redirection setting by a function', () => {
+    test('should redirect to login page', async () => {
+      const redirect = { login: (ctx) => '/login?param=test2' }
+      const nuxt = await initNuxt({
+        ...config,
+        ...{
+          auth: { ...config.auth, ...{ redirect } }
+        }
+      })
+      const page = await browser.newPage()
+      await page.goto(url('/secure'))
+
+      const currentUri = await page.evaluate(() => window.location.href)
+
+      await page.close()
+      await nuxt.close()
+
+      expect(currentUri).toBe(url('/login?param=test2'))
+    }, 60000)
+  })
+})


### PR DESCRIPTION
allow to add a function to redirection configuration of `nuxt.config.js` 

that takes `Nuxt Context` as argument.

we can possible to implement redirection more flexibly.

## Use-case

* redirect to the previous page after login without using cookie (relate #[134](https://github.com/nuxt-community/auth-module/issues/134#issuecomment-408333700)

nuxt.config.js
```javascript
module.exports = 
  .....
  auth: {
    .....
    rewriteRedirects: false, // do not call $storage.setUniversal('redirect', xxxxx)
    redirect: {
      login: (ctx) => `/signin?redirect=${encodeURIComponent(ctx.route.fullPath)}`,
      home: (ctx) => {
        if (ctx.query.redirect) {
          return ctx.query.redirect
        }
        return '/home'
      }
    }
  }
}
```

* with nuxt-i18n module

nuxt.config.js
```javascript
module.exports = 
  .....
  auth: {
    .....
    redirect: {
      // generate path using localePath method
      login: (ctx) => ctx.app.localePath('signin'),
      home: (ctx) => ctx.app.localePath('home')  
    }
  }
}
```

