### PR TITLE
docs: fix onError example

### DIFF
--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -105,8 +105,8 @@ this.$auth.setToken('local', '.....')
 Listen for auth errors: (`plugins/auth.js`)
 
 ```js
-export default function({ $auth }) {
-  $auth.onError((error, name, endpoint) => {
+export default function({ app }) {
+  app.$auth.onError((error, name, endpoint) => {
     console.error(name, error)
   })
 }


### PR DESCRIPTION
It seems to need context.app.$auth to work.

I copied the approach used in https://auth.nuxtjs.org/recipes/extend and it worked.

Thanks for the excellent module BTW :+1: 