### PR TITLE
feat(core): support server set cookies

### DIFF
--- a/lib/core/storage.js
+++ b/lib/core/storage.js
@@ -182,24 +182,17 @@ export default class Storage {
 
       // Support server set cookies
       if (process.server) {
-        let setCookieHeader = this.ctx.res.getHeader('Set-Cookie')
-        if (!setCookieHeader) {
-          setCookieHeader = []
-        }
-        const existingCookieIndex = setCookieHeader.findIndex(element => element.split('=')[0] === _key)
-        if (existingCookieIndex === -1) {
-          setCookieHeader.push(_key + '=' + value)
-        } else {
-          // Convert the options object to a semicolon-separated key-value string
-          // { Expires: "Wed, 7 Oct...", Domain: "example.com" } => "Expires=Wed, 7 Oct...; Domain=example.com"
-          const optionsString = Object.keys(_options).reduce(
-            (accumulator, key) => {
-              return accumulator + '; ' + key + '=' + _options[key]
-            },
-            '')
-          setCookieHeader[existingCookieIndex] = _key + '=' + value  + optionsString
-        }
-        this.ctx.res.setHeader('Set-Cookie', setCookieHeader)
+        const existingCookieArray = this.ctx.res.getHeader('Set-Cookie')
+
+        // Convert cookie array to cookie string
+        const cookies = existingCookieArray ? parseCookie(existingCookieArray.join('; ')) : {}
+
+        // Set or update the cookie
+        cookies[_key] = value
+
+        // Convert back to array and set the header
+        const newCookieArray = Object.keys(cookies).map(key => serializeCookie(key, cookies[key]))
+        this.ctx.res.setHeader('Set-Cookie', newCookieArray)
       } else {
         Cookies.set(_key, value, _options)
       }

--- a/lib/core/storage.js
+++ b/lib/core/storage.js
@@ -182,16 +182,17 @@ export default class Storage {
 
       // Support server set cookies
       if (process.server) {
+        const { parse, serialize } = require('cookie')
         const existingCookieArray = this.ctx.res.getHeader('Set-Cookie')
 
         // Convert cookie array to cookie string
-        const cookies = existingCookieArray ? parseCookie(existingCookieArray.join('; ')) : {}
+        const cookies = existingCookieArray ? parse(existingCookieArray.join('; ')) : {}
 
         // Set or update the cookie
         cookies[_key] = value
 
         // Convert back to array and set the header
-        const newCookieArray = Object.keys(cookies).map(key => serializeCookie(key, cookies[key]))
+        const newCookieArray = Object.keys(cookies).map(key => serialize(key, cookies[key]))
         this.ctx.res.setHeader('Set-Cookie', newCookieArray)
       } else {
         Cookies.set(_key, value, _options)

--- a/lib/core/storage.js
+++ b/lib/core/storage.js
@@ -3,7 +3,7 @@ import Cookies from 'js-cookie'
 import getProp from 'dotprop'
 import { parse as parseCookie } from 'cookie'
 
-import { isUnset, isSet } from './utilities'
+import { isUnset, isSet, setResponseHeaderCookies, getCookiesFromResponseHeader } from './utilities'
 
 export default class Storage {
   constructor (ctx, options) {
@@ -177,26 +177,22 @@ export default class Storage {
     const _options = Object.assign({}, this.options.cookie.options, options)
 
     if (isUnset(value)) {
-      Cookies.remove(_key, _options)
-    } else {
-
-      // Support server set cookies
       if (process.server) {
-        const { parse, serialize } = require('cookie')
-        const existingCookieArray = this.ctx.res.getHeader('Set-Cookie')
-
-        // Convert cookie array to cookie string
-        const cookies = existingCookieArray ? parse(existingCookieArray.join('; ')) : {}
-
-        // Set or update the cookie
-        cookies[_key] = value
-
-        // Convert back to array and set the header
-        const newCookieArray = Object.keys(cookies).map(key => serialize(key, cookies[key]))
-        this.ctx.res.setHeader('Set-Cookie', newCookieArray)
+        const cookies = getCookiesFromResponseHeader(this.ctx)
+        delete cookies[_key]
+        setResponseHeaderCookies(this.ctx, cookies)
       } else {
-        Cookies.set(_key, value, _options)
+        Cookies.remove(_key, _options)
       }
+      return value
+    }
+
+    if (process.server) {
+      const cookies = getCookiesFromResponseHeader(this.ctx)
+      cookies[_key] = value
+      setResponseHeaderCookies(this.ctx, cookies)
+    } else {
+      Cookies.set(_key, value, _options)
     }
     return value
   }

--- a/lib/core/storage.js
+++ b/lib/core/storage.js
@@ -182,12 +182,28 @@ export default class Storage {
 
       // Support server set cookies
       if (process.server) {
-        this.ctx.res.setHeader('Set-Cookie', [_key + '=' + value])
+        let setCookieHeader = this.ctx.res.getHeader('Set-Cookie')
+        if (!setCookieHeader) {
+          setCookieHeader = []
+        }
+        const existingCookieIndex = setCookieHeader.findIndex(element => element.split('=')[0] === _key)
+        if (existingCookieIndex === -1) {
+          setCookieHeader.push(_key + '=' + value)
+        } else {
+          // Convert the options object to a semicolon-separated key-value string
+          // { Expires: "Wed, 7 Oct...", Domain: "example.com" } => "Expires=Wed, 7 Oct...; Domain=example.com"
+          const optionsString = Object.keys(_options).reduce(
+            (accumulator, key) => {
+              return accumulator + '; ' + key + '=' + _options[key]
+            },
+            '')
+          setCookieHeader[existingCookieIndex] = _key + '=' + value  + optionsString
+        }
+        this.ctx.res.setHeader('Set-Cookie', setCookieHeader)
       } else {
         Cookies.set(_key, value, _options)
       }
     }
-
     return value
   }
 

--- a/lib/core/storage.js
+++ b/lib/core/storage.js
@@ -168,7 +168,7 @@ export default class Storage {
   // ------------------------------------
 
   setCookie (key, value, options = {}) {
-    if (process.server || !this.options.cookie) {
+    if (!this.options.cookie) {
       return
     }
 
@@ -179,7 +179,13 @@ export default class Storage {
     if (isUnset(value)) {
       Cookies.remove(_key, _options)
     } else {
-      Cookies.set(_key, value, _options)
+
+      // Support server set cookies
+      if (process.server) {
+        this.ctx.res.setHeader('Set-Cookie', [_key + '=' + value])
+      } else {
+        Cookies.set(_key, value, _options)
+      }
     }
 
     return value

--- a/lib/core/utilities.js
+++ b/lib/core/utilities.js
@@ -1,3 +1,5 @@
+import { parse as parseCookie, serialize as serializeCookie } from 'cookie'
+
 export const isUnset = o => typeof o === 'undefined' || o === null
 export const isSet = o => !isUnset(o)
 
@@ -64,4 +66,23 @@ export function normalizePath (path = '') {
   }
 
   return result
+}
+
+// ------------------------------------
+// Server side cookie helpers
+// ------------------------------------
+
+export const getCookiesFromResponseHeader = context => {
+  const cookieArray = context.res.getHeader('Set-Cookie')
+
+  if (cookieArray === undefined) {
+    return {}
+  }
+  const cookieString = cookieArray.join('; ')
+  return parseCookie(cookieString)
+}
+
+export const setResponseHeaderCookies = (context, cookies) => {
+  const cookieArray = Object.keys(cookies).map(key => serializeCookie(key, cookies[key]))
+  context.res.setHeader('Set-Cookie', cookieArray)
 }


### PR DESCRIPTION
This fixes the issue that arises when trying to access a protected path directly(the first request to the website). The middleware tries to save the attempted, protected path to storage, so that we can redirect to the path after login. The problem was that the "auth.redirect" cookie was not set when the middleware was run server side. This PR supports cookies set server side and should fix #332, fixes #326 and fixes #134.