### PR TITLE
Add error listeners before Auth.init()

### DIFF
--- a/lib/module/defaults.js
+++ b/lib/module/defaults.js
@@ -2,6 +2,7 @@ module.exports = {
   //  -- Error handling --
 
   resetOnError: false,
+  errorListeners: [],
 
   // -- Authorization --
 

--- a/lib/module/plugin.js
+++ b/lib/module/plugin.js
@@ -4,6 +4,7 @@ import './middleware'
 
 // Active schemes
 <%= options.uniqueSchemes.map(path =>`import ${'scheme_' + hash(path)} from '${path.replace(/\\/g,'/')}'`).join('\n') %>
+<%= options.options.errorListeners.map(path =>`import ${'listener_' + hash(path)} from '${path.replace(/\\/g,'/')}'`).join('\n') %>
 
 export default function (ctx, inject) {
   // Options
@@ -14,6 +15,10 @@ export default function (ctx, inject) {
 
   // Inject it to nuxt context as $auth
   inject('auth', $auth)
+
+  // Load error listeners
+
+  <%= options.options.errorListeners.map(path =>`$auth.onError(${'listener_' + hash(path)})`).join('\n') %>
 
   // Register strategies
 


### PR DESCRIPTION
In the current setup, if you want to create an error listener, you
should create a plugin, and load them through the config with the
setting auth.plugins, like so:

`plugins: ['~/plugins/auth-error-listener.js']`

The plugins are loaded *after* the main Auth plugin itself is loaded.
The main plugin takes care of the init. So if an error occurs during
init, it's impossible to catch it with a custom error listener. As mentioned
in issue #220.

This commit adds a new config option, called `errorListeners`, it's used
in the same way as plugins, so:

`errorListeners: ['~/utils/auth-error-listener.js']`

The listener itself isn't a nuxt plugin anymore. It should export a
default function:

```
export default function(error) {
  console.log('error listener')
  console.log(error.response.data)
  console.log(error.response.status)
}
```

ErrorListeners will be loaded *before* init. This change should be
backwards compatible, since the old method of loading listeners through
plugins still works.