### PR TITLE
fix(local): prevent `loggedIn` being incorrectly set to true when user is disabled

### DIFF
--- a/lib/schemes/local.js
+++ b/lib/schemes/local.js
@@ -71,14 +71,14 @@ export default class LocalScheme {
   }
 
   async fetchUser (endpoint) {
+    // Token is required but not available
+    if (this.options.tokenRequired && !this.$auth.getToken(this.name)) {
+      return
+    }
+    
     // User endpoint is disabled.
     if (!this.options.endpoints.user) {
       this.$auth.setUser({})
-      return
-    }
-
-    // Token is required but not available
-    if (this.options.tokenRequired && !this.$auth.getToken(this.name)) {
       return
     }
 


### PR DESCRIPTION
This fixes an issue with the local scheme which sets the user to `{}` even if there's no token, which causes loggedIn to report true, when in fact it's false.