### PR TITLE
feat(oauth2): support passing extra query params

### DIFF
--- a/docs/schemes/oauth2.md
+++ b/docs/schemes/oauth2.md
@@ -26,8 +26,16 @@ auth: {
 ```
 
 ```js
-this.$auth.loginWith('social')
+this.$auth.loginWith('social', options)
 ```
+
+`options` is an optional object with `params` property defining additional URL parameters to pass to authorization endpoint. For example:
+
+```js
+this.$auth.loginWith('social', { params: { lang: 'en' } })
+```
+
+will add extra query parameter `&lang=en` to a URL.
 
 ### `authorization_endpoint`
 

--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -63,7 +63,7 @@ export default class Oauth2Scheme {
     return this.$auth.reset()
   }
 
-  login () {
+  login ({ params } = {}) {
     const opts = {
       protocol: 'oauth2',
       response_type: this.options.response_type,
@@ -73,6 +73,7 @@ export default class Oauth2Scheme {
       // Note: The primary reason for using the state parameter is to mitigate CSRF attacks.
       // @see: https://auth0.com/docs/protocols/oauth2/oauth-state
       state: this.options.state || randomString(),
+      ...params,
     };
 
     if (this.options.audience) {


### PR DESCRIPTION
Enables one to add extra params to oauth2 authorization endpoint before
navigating to it.

fixes #349