### PR TITLE
fix(module): warn if default strategy is not valid

### DIFF
--- a/lib/module/index.js
+++ b/lib/module/index.js
@@ -24,10 +24,13 @@ module.exports = function (moduleOptions) {
   delete options.strategies
 
   // Set defaultStrategy
-  if (!options.defaultStrategy && strategies.length) {
-    options.defaultStrategy = strategies[0]._name
-  } else {
+  const strategyNames = strategies.map(x => x._name)
+  options.defaultStrategy = options.defaultStrategy || strategyNames[0]
+
+  if (!options.defaultStrategy) {
     logger.warn('no strategy defined!')
+  } else if(strategyNames.indexOf(options.defaultStrategy) === -1) {
+    logger.warn(`strategy ${options.defaultStrategy} is not defined!`)
   }
 
   // Copy plugin


### PR DESCRIPTION
Fixed a bug when 'no strategy defined!' is displayed when options.defaultStrategy is set.
Added a warning when the strategy specified in options.defaultStrategy is not a valid strategy.