### PR TITLE
fix: server side Set-Cookie always set an array.

### DIFF
--- a/lib/core/storage.js
+++ b/lib/core/storage.js
@@ -226,14 +226,8 @@ export default class Storage {
       document.cookie = serializedCookie
     } else if (process.server && this.ctx.res) {
       // Send Set-Cookie header from server side
-      const prev = this.ctx.res.getHeader('Set-Cookie')
-      let value = serializedCookie
-      if (prev) {
-        value = Array.isArray(prev)
-          ? prev.concat(serializedCookie)
-          : [prev, serializedCookie]
-      } else value = [serializedCookie] // setHeader Set-Cookie with a string cannot be upconverted to an array
-      this.ctx.res.setHeader('Set-Cookie', value)
+      const prevCookies = this.ctx.res.getHeader('Set-Cookie')
+      this.ctx.res.setHeader('Set-Cookie', [].concat(prevCookies, serializeCookie))
     }
 
     return value

--- a/lib/core/storage.js
+++ b/lib/core/storage.js
@@ -232,7 +232,7 @@ export default class Storage {
         value = Array.isArray(prev)
           ? prev.concat(serializedCookie)
           : [prev, serializedCookie]
-      }
+      } else value = [serializedCookie] // setHeader Set-Cookie with a string cannot be upconverted to an array
       this.ctx.res.setHeader('Set-Cookie', value)
     }
 


### PR DESCRIPTION
Explanation. nodejs expects setHeader('Set-Cookie', value) to be
an array. If given a string it will accept and properly send it.
However, any subsequent attempts to replace the string with an array
to send multiple Set-Cookie headers will fail; it will instead send a
single Set-Cookie header with a concatenated array. The client will only
parse the first cookie, and then you'll spend hours pulling your
hair out.

Example:

res.SetHeader('Set-Cookie', 'serialized cookie')
res.SetHeader('Set-Cookie', ['serialized cookie','another cookie'])

generates

Set-Cookie: serialized cookie,another cookie

when what you want is

Set-Cookie: serialized cookie
Set-Cookie: another cookie