### PR TITLE
docs: fix path to plugin extend documentation

### DIFF
--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -110,7 +110,7 @@ Otherwise the auth token will be stored in a cookie named by default as: `auth._
 
 If you have any nuxt plugin that depends on `$auth` you have to specify it here instead of top-level `plugins` option in `nuxt.config.js`.
 
-See [Extending Auth Plugin](recipes/extend.md)
+See [Extending Auth Plugin](/recipes/extend.md)
 
 ## `resetOnError`
 


### PR DESCRIPTION
The link on the options page to the extend recipe was relative to the
api directory but the file was not.