### PR TITLE
fix: set-cookie header contains `undefined` value

### DIFF
--- a/lib/core/storage.js
+++ b/lib/core/storage.js
@@ -227,7 +227,7 @@ export default class Storage {
     } else if (process.server && this.ctx.res) {
       // Send Set-Cookie header from server side
       const prevCookies = this.ctx.res.getHeader('Set-Cookie')
-      this.ctx.res.setHeader('Set-Cookie', [].concat(prevCookies, serializedCookie))
+      this.ctx.res.setHeader('Set-Cookie', [].concat(prevCookies, serializedCookie).filter(v => v))
     }
 
     return value


### PR DESCRIPTION
relate #367 

Set-Cookie header contains `undefined` value when `prevCookies` is empty

## screen shot

<img width="335" alt="スクリーンショット 2019-06-05 23 32 05" src="https://user-images.githubusercontent.com/4970917/58967545-5b49af80-87ef-11e9-957b-8b69aac22a57.png">



