### PR TITLE
In docs add logout info re Auth0

### DIFF
--- a/docs/providers/auth0.md
+++ b/docs/providers/auth0.md
@@ -40,3 +40,23 @@ User will be redirected to a page like this:
 You can get your `client_id` and `domain` the Settings section for your client in the [Auth0 API dashboard](https://manage.auth0.com/#/applications). Your audience is defined on your [client's API](https://manage.auth0.com/#/apis).
 
 <img align="center" src="https://cdn2.auth0.com/docs/media/articles/dashboard/client_settings.png">
+
+## Logout with new Auth0 tenants
+
+Auth0 tenants created in 2018 and earlier had an optional tenant setting  `Enable Seamless SSO`. This setting is automatically enabled for new tenants and cannot be disabled.
+
+If enabled and a user logs out and logs back in a short while later, they will not need to re-enter their credentials. They'll be logged in automatically. 
+
+You can force Auth0 to present the login page:
+* Go to into the `Tenant Settings` > `Advanced`
+* In `Allowed Logout URLs` enter the allowed URL(s) you can redirect to, such as `http://localhost:3000`
+
+Wherever you have a logout feature do two things:
+  1. run the logout command
+```js
+this.$auth.logout()
+```
+  2. redirect the user to the Auth0 logout URL along with a `returnTo` parameter 
+```
+https://mytenant.auth0.com/v2/logout?returnTo=http%3A%2F%2Flocalhost:3000
+```


### PR DESCRIPTION
As discussed in issue #375 there's a new setting that's automatically enabled in new Auth0 tenants, which means that logged out users that log back in a short while later are automatically logged in. Auth0 doesn't show the login page. 

This extra bit of documentation explains to work around this, as described in issue #375.