### PR TITLE
feat(oauth2): support server-side callback

### DIFF
--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -3,7 +3,7 @@
 [Source Code](https://github.com/nuxt-community/auth-module/blob/dev/lib/core/auth.js)
 
 This module globally injects `$auth` instance, meaning that you can access it anywhere using `this.$auth`.
-For plugins, asyncData, fetch, nuxtServerInit and Middleware, you can access it from `context.app.$auth`.
+For plugins, asyncData, fetch, nuxtServerInit and Middleware, you can access it from `context.$auth`.
 
 ## properties
 
@@ -118,8 +118,8 @@ this.$auth.setToken('local', '.....')
 Listen for auth errors: (`plugins/auth.js`)
 
 ```js
-export default function({ app }) {
-  app.$auth.onError((error, name, endpoint) => {
+export default function({ $auth }) {
+  $auth.onError((error, name, endpoint) => {
     console.error(name, error)
   })
 }
@@ -130,8 +130,8 @@ export default function({ app }) {
  Pre-process URLs before redirect: (`plugins/auth.js`)
 
  ```js
-export default function({ app }) {
-  app.$auth.onRedirect((to, from) => {
+export default function({ $auth }) {
+  $auth.onRedirect((to, from) => {
     console.error(to)
     // you can optionally change `to` by returning a new value
   })

--- a/docs/recipes/extend.md
+++ b/docs/recipes/extend.md
@@ -18,11 +18,11 @@ If you have plugins that need to access `$auth`, you can use `auth.plugins` opti
 `plugins/auth.js`
 
 ```js
-export default function ({ app }) {
-  if (!app.$auth.loggedIn) {
+export default function ({ $auth }) {
+  if (!$auth.loggedIn) {
     return
   }
 
-  const username = app.$auth.user.username
+  const username = $auth.user.username
 }
 ```

--- a/lib/core/middleware.js
+++ b/lib/core/middleware.js
@@ -14,16 +14,16 @@ Middleware.auth = function (ctx) {
     return
   }
 
-  const { login, callback } = ctx.app.$auth.options.redirect
+  const { login, callback } = ctx.$auth.options.redirect
 
-  if (ctx.app.$auth.$state.loggedIn) {
+  if (ctx.$auth.$state.loggedIn) {
     // -- Authorized --
     // Redirect to home page if:
     // - inside login page
     // - login page disabled
     // - options: { auth: 'guest' } is set on the page
     if (!login || normalizePath(ctx.route.path) === normalizePath(login) || routeOption(ctx.route, 'auth', 'guest')) {
-      ctx.app.$auth.redirect('home')
+      ctx.$auth.redirect('home')
     }
   } else {
     // -- Guest --
@@ -31,7 +31,7 @@ Middleware.auth = function (ctx) {
     // (Those passing `callback` at runtime need to mark their callback component
     // with `auth: false` to avoid an unnecessary redirect from callback to login)
     if (!callback || normalizePath(ctx.route.path) !== normalizePath(callback)) {
-      ctx.app.$auth.redirect('login')
+      ctx.$auth.redirect('login')
     }
   }
 }

--- a/lib/module/plugin.js
+++ b/lib/module/plugin.js
@@ -12,11 +12,7 @@ export default function (ctx, inject) {
   // Create a new Auth instance
   const $auth = new Auth(ctx, options)
 
-  // Inject it to nuxt context as $auth
-  inject('auth', $auth)
-
   // Register strategies
-
   <%=
   options.strategies.map(strategy => {
     const scheme = 'scheme_' + hash(options.strategyScheme.get(strategy))
@@ -25,6 +21,9 @@ export default function (ctx, inject) {
     return `// ${name}\n  $auth.registerStrategy('${name}', new ${scheme}($auth, ${schemeOptions}))`
   }).join('\n\n  ')
   %>
+
+  // Inject it to nuxt context as $auth
+  inject('auth', $auth)
 
   // Initialize auth
   return $auth.init().catch(error => {

--- a/lib/module/plugin.js
+++ b/lib/module/plugin.js
@@ -24,6 +24,7 @@ export default function (ctx, inject) {
 
   // Inject it to nuxt context as $auth
   inject('auth', $auth)
+  ctx.$auth = $auth
 
   // Initialize auth
   return $auth.init().catch(error => {

--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -1,4 +1,4 @@
-import { encodeQuery, parseQuery } from '../utilities'
+import { encodeQuery } from '../utilities'
 import nanoid from 'nanoid'
 const isHttps = process.server ? require('is-https') : null
 

--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -133,7 +133,7 @@ export default class Oauth2Scheme {
       return
     }
 
-    const parsedQuery = Object.assign({}, this.$auth.ctx.query, this.$auth.ctx.hash)
+    const parsedQuery = Object.assign({}, this.$auth.ctx.route.query, this.$auth.ctx.route.hash)
     // accessToken/idToken
     let token = parsedQuery[this.options.token_key || 'access_token']
     // refresh token

--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -5,7 +5,8 @@ const isHttps = process.server ? require('is-https') : null
 const DEFAULTS = {
   token_type: 'Bearer',
   response_type: 'token',
-  tokenName: 'Authorization'
+  tokenName: 'Authorization',
+  transform_credentials_endpoint: null
 }
 
 export default class Oauth2Scheme {
@@ -139,9 +140,16 @@ export default class Oauth2Scheme {
     // refresh token
     let refreshToken = parsedQuery[this.options.refresh_token_key || 'refresh_token']
 
+    // Validate state
+    const state = this.$auth.$storage.getUniversal(this.name + '.state')
+    this.$auth.$storage.setUniversal(this.name + '.state', null)
+    if (state && parsedQuery.state !== state) {
+      return
+    }
+
     // -- Authorization Code Grant --
     if (this.options.response_type === 'code' && parsedQuery.code) {
-      const data = await this.$auth.request({
+      let data = await this.$auth.request({
         method: 'post',
         url: this.options.access_token_endpoint,
         baseURL: process.server ? undefined : false,
@@ -155,6 +163,16 @@ export default class Oauth2Scheme {
         })
       })
 
+      // Transform credentials (SSR Oauth on API side)
+      if (this.options.transform_credentials_endpoint) {
+        data = await this.$auth.request({
+          method: 'post',
+          url: this.options.transform_credentials_endpoint,
+          data
+        })
+      }
+
+
       if (data.access_token) {
         token = data.access_token
       }
@@ -165,13 +183,6 @@ export default class Oauth2Scheme {
     }
 
     if (!token || !token.length) {
-      return
-    }
-
-    // Validate state
-    const state = this.$auth.$storage.getUniversal(this.name + '.state')
-    this.$auth.$storage.setUniversal(this.name + '.state', null)
-    if (state && parsedQuery.state !== state) {
       return
     }
 

--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -144,7 +144,6 @@ export default class Oauth2Scheme {
       const data = await this.$auth.request({
         method: 'post',
         url: this.options.access_token_endpoint,
-        baseURL: process.server ? undefined : false,
         data: encodeQuery({
           code: parsedQuery.code,
           client_id: this.options.client_id,

--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -172,7 +172,6 @@ export default class Oauth2Scheme {
         })
       }
 
-
       if (data.access_token) {
         token = data.access_token
       }

--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -144,6 +144,7 @@ export default class Oauth2Scheme {
       const data = await this.$auth.request({
         method: 'post',
         url: this.options.access_token_endpoint,
+        baseURL: process.server ? undefined : false,
         data: encodeQuery({
           code: parsedQuery.code,
           client_id: this.options.client_id,

--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -5,8 +5,7 @@ const isHttps = process.server ? require('is-https') : null
 const DEFAULTS = {
   token_type: 'Bearer',
   response_type: 'token',
-  tokenName: 'Authorization',
-  transform_credentials_endpoint: null
+  tokenName: 'Authorization'
 }
 
 export default class Oauth2Scheme {
@@ -162,15 +161,6 @@ export default class Oauth2Scheme {
           grant_type: this.options.grant_type
         })
       })
-
-      // Transform credentials (SSR Oauth on API side)
-      if (this.options.transform_credentials_endpoint) {
-        data = await this.$auth.request({
-          method: 'post',
-          url: this.options.transform_credentials_endpoint,
-          data
-        })
-      }
 
       if (data.access_token) {
         token = data.access_token

--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -1,5 +1,6 @@
 import { encodeQuery, parseQuery } from '../utilities'
 import nanoid from 'nanoid'
+const isHttps = process.server ? require('is-https') : null
 
 const DEFAULTS = {
   token_type: 'Bearer',
@@ -10,6 +11,7 @@ const DEFAULTS = {
 export default class Oauth2Scheme {
   constructor (auth, options) {
     this.$auth = auth
+    this.req = auth.ctx.req
     this.name = options._name
 
     this.options = Object.assign({}, DEFAULTS, options)
@@ -26,6 +28,12 @@ export default class Oauth2Scheme {
 
     if (url) {
       return url
+    }
+
+    if (process.server && this.req) {
+      const protocol = 'http' + (isHttps(this.req) ? 's' : '') + '://'
+
+      return protocol + this.req.headers.host + this.$auth.options.redirect.callback
     }
 
     if (process.client) {
@@ -91,7 +99,7 @@ export default class Oauth2Scheme {
       opts.nonce = nonce || nanoid()
     }
 
-    this.$auth.$storage.setLocalStorage(this.name + '.state', opts.state)
+    this.$auth.$storage.setUniversal(this.name + '.state', opts.state)
 
     const url = this.options.authorization_endpoint + '?' + encodeQuery(opts)
 
@@ -116,19 +124,18 @@ export default class Oauth2Scheme {
   }
 
   async _handleCallback (uri) {
-    // Callback flow is not supported in server side
-    if (process.server) {
+    // Handle callback only for specified route
+    if (this.$auth.options.redirect && this.$auth.ctx.route.path !== this.$auth.options.redirect.callback) {
+      return
+    }
+    // Callback flow is not supported in static generation
+    if (process.server && process.static) {
       return
     }
 
-    // Parse query from both search and hash fragments
-    const hash = parseQuery(window.location.hash.substr(1))
-    const search = parseQuery(window.location.search.substr(1))
-    const parsedQuery = Object.assign({}, search, hash)
-
+    const parsedQuery = Object.assign({}, this.$auth.ctx.query, this.$auth.ctx.hash)
     // accessToken/idToken
     let token = parsedQuery[this.options.token_key || 'access_token']
-
     // refresh token
     let refreshToken = parsedQuery[this.options.refresh_token_key || 'refresh_token']
 
@@ -137,7 +144,7 @@ export default class Oauth2Scheme {
       const data = await this.$auth.request({
         method: 'post',
         url: this.options.access_token_endpoint,
-        baseURL: false,
+        baseURL: process.server ? undefined : false,
         data: encodeQuery({
           code: parsedQuery.code,
           client_id: this.options.client_id,
@@ -162,8 +169,8 @@ export default class Oauth2Scheme {
     }
 
     // Validate state
-    const state = this.$auth.$storage.getLocalStorage(this.name + '.state')
-    this.$auth.$storage.setLocalStorage(this.name + '.state', null)
+    const state = this.$auth.$storage.getUniversal(this.name + '.state')
+    this.$auth.$storage.setUniversal(this.name + '.state', null)
     if (state && parsedQuery.state !== state) {
       return
     }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "consola": "^2.7.1",
     "cookie": "^0.4.0",
     "dotprop": "^1.2.0",
+    "is-https": "^1.0.0",
     "js-cookie": "^2.2.0",
     "lodash": "^4.17.11",
     "nanoid": "^2.0.3"

--- a/test/fixtures/basic/plugins/auth.js
+++ b/test/fixtures/basic/plugins/auth.js
@@ -1,3 +1,3 @@
-export default function ({ app }) {
-  app.$auth._custom_plugin = true
+export default function ({ $auth }) {
+  $auth._custom_plugin = true
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5214,6 +5214,11 @@ is-glob@^4.0.0, is-glob@^4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
+is-https@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-https/-/is-https-1.0.0.tgz#9c1dde000dc7e7288edb983bef379e498e7cb1bf"
+  integrity sha512-1adLLwZT9XEXjzhQhZxd75uxf0l+xI9uTSFaZeSESjL3E1eXSPpO+u5RcgqtzeZ1KCaNvtEwZSTO2P4U5erVqQ==
+
 is-number@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"


### PR DESCRIPTION
**Bonus:** I added `$auth` in context for easier usage in `asyncData`

This PR is to enhance the DX on the callback redirect page to support SSR redirect.

It also avoid calling the provider (ex: GitHub) if the query params are not on the callback route.

Before:

![nuxt-auth-oauth-csr](https://user-images.githubusercontent.com/904724/59699167-663e1000-91f1-11e9-9a07-5b8a3c616c71.gif)

After:

![nuxt-auth-oauth-ssr](https://user-images.githubusercontent.com/904724/59699170-6a6a2d80-91f1-11e9-9ae2-83cd4b2b53a2.gif)
