### PR TITLE
fix: don't redirect to login page if in guest mode

### DIFF
--- a/lib/core/middleware.js
+++ b/lib/core/middleware.js
@@ -15,22 +15,20 @@ Middleware.auth = function (ctx) {
   }
 
   const { login, callback } = ctx.app.$auth.options.redirect
+  const pageIsInGuestMode = routeOption(ctx.route, 'auth', 'guest')
+  const insideLoginPage = normalizePath(ctx.route.path) === normalizePath(login)
+  const insideCallbackPage = normalizePath(ctx.route.path) !== normalizePath(callback)
 
   if (ctx.app.$auth.$state.loggedIn) {
     // -- Authorized --
-    // Redirect to home page if:
-    // - inside login page
-    // - login page disabled
-    // - options: { auth: 'guest' } is set on the page
-    if (!login || normalizePath(ctx.route.path) === normalizePath(login) || routeOption(ctx.route, 'auth', 'guest')) {
+    if (!login || insideLoginPage || pageIsInGuestMode) {
       ctx.app.$auth.redirect('home')
     }
   } else {
     // -- Guest --
-    // Redirect to login page if not authorized and not inside callback page
     // (Those passing `callback` at runtime need to mark their callback component
     // with `auth: false` to avoid an unnecessary redirect from callback to login)
-    if (!callback || normalizePath(ctx.route.path) !== normalizePath(callback)) {
+    if (!pageIsInGuestMode && (!callback || insideCallbackPage)) {
       ctx.app.$auth.redirect('login')
     }
   }


### PR DESCRIPTION
At the moment when `auth: 'guest'` is set on a page it always redirect an unauthed user to `login`, which I think is not the desired effect.

This PR fixes this, as unauthed users are now not redirected to `login`.

I also took the liberty to make the code more self-explanatory.

Related issue: #383 