### PR TITLE
feat: readOnly cookie to support httpOnly

### DIFF
--- a/lib/core/storage.js
+++ b/lib/core/storage.js
@@ -201,7 +201,7 @@ export default class Storage {
   }
 
   setCookie (key, value, options = {}) {
-    if (!this.options.cookie || (process.server && !this.ctx.res)) {
+    if (!this.options.cookie || (process.server && !this.ctx.res) || this.options.cookie.readOnly) {
       return
     }
 

--- a/lib/module/defaults.js
+++ b/lib/module/defaults.js
@@ -33,7 +33,8 @@ module.exports = {
   cookie: {
     prefix: 'auth.',
     options: {
-      path: '/'
+      path: '/',
+      readOnly: false
     }
   },
 


### PR DESCRIPTION
Add options.cookie.readOnly.
This option is helpful when you want to set httpOnly cookie on the server side(e.g. using serverMiddleware) and do not want to override it on the client side.

Setting options.cookie = false does not help this situation because it disables syncUniversal with data fetched from cookie on the server side.