### PR TITLE
fix: regression from #385 when callback is set to false

### DIFF
--- a/lib/core/middleware.js
+++ b/lib/core/middleware.js
@@ -15,22 +15,20 @@ Middleware.auth = function (ctx) {
   }
 
   const { login, callback } = ctx.app.$auth.options.redirect
+  const pageIsInGuestMode = routeOption(ctx.route, 'auth', 'guest')
+  const insideLoginPage = normalizePath(ctx.route.path) === normalizePath(login)
+  const insideCallbackPage = normalizePath(ctx.route.path) !== normalizePath(callback)
 
   if (ctx.app.$auth.$state.loggedIn) {
     // -- Authorized --
-    // Redirect to home page if:
-    // - inside login page
-    // - login page disabled
-    // - options: { auth: 'guest' } is set on the page
-    if (!login || normalizePath(ctx.route.path) === normalizePath(login) || routeOption(ctx.route, 'auth', 'guest')) {
+    if (!login || insideLoginPage || pageIsInGuestMode) {
       ctx.app.$auth.redirect('home')
     }
   } else {
     // -- Guest --
-    // Redirect to login page if not authorized and not inside callback page
     // (Those passing `callback` at runtime need to mark their callback component
     // with `auth: false` to avoid an unnecessary redirect from callback to login)
-    if (!callback || normalizePath(ctx.route.path) !== normalizePath(callback)) {
+    if (!pageIsInGuestMode && (!callback || insideCallbackPage)) {
       ctx.app.$auth.redirect('login')
     }
   }


### PR DESCRIPTION
As I [commented](https://github.com/nuxt-community/auth-module/pull/385#issuecomment-504780423) in PR #385, I actually introduced a regression when `callback: false` is set in redirect options,
as it tries to call `normalizePath(callback)`, which calls `callback.split()`, which is not possible when it is set to `false` instead of a `string`.

This PR fixes this.