### PR TITLE
fix(oauth2): correctly handle callback with hash

### DIFF
--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -1,4 +1,4 @@
-import { encodeQuery } from '../utilities'
+import { encodeQuery, parseQuery } from '../utilities'
 import nanoid from 'nanoid'
 const isHttps = process.server ? require('is-https') : null
 
@@ -133,7 +133,8 @@ export default class Oauth2Scheme {
       return
     }
 
-    const parsedQuery = Object.assign({}, this.$auth.ctx.route.query, this.$auth.ctx.route.hash)
+    const hash = parseQuery(this.$auth.ctx.route.hash.substr(1))
+    const parsedQuery = Object.assign({}, this.$auth.ctx.route.query, hash)
     // accessToken/idToken
     let token = parsedQuery[this.options.token_key || 'access_token']
     // refresh token
@@ -148,7 +149,7 @@ export default class Oauth2Scheme {
 
     // -- Authorization Code Grant --
     if (this.options.response_type === 'code' && parsedQuery.code) {
-      let data = await this.$auth.request({
+      const data = await this.$auth.request({
         method: 'post',
         url: this.options.access_token_endpoint,
         baseURL: process.server ? undefined : false,


### PR DESCRIPTION
This fixes #393

Problem is that with the latest introduction of server-side callback handling #381, the parsing of the hash was removed and therefore the information provided by the oauth clients can not be extracted anymore.