### PR TITLE
Fixed broken link in Setup auth middleware

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -7,7 +7,7 @@ Zero-boilerplate authentication support for Nuxt.js!
 If it is first time using this module, reading resources below in order is recommended:
 
 1. [Add auth and axios modules](./guide/setup.md)
-2. [Setup auth middleware](./guide/middleware)
+2. [Setup auth middleware](./guide/middleware.md)
 3. [Configure local scheme](./schemes/local.md)
 4. [Customize options](./api/options.md)
 5. [Use `$auth` service](./api/auth.md)


### PR DESCRIPTION
The link of "Setup auth middleware" in /auth-module/docs/readme.md was broken, so it was fixed.