### PR TITLE
chore: collect coverage from lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,11 @@
   ],
   "jest": {
     "testEnvironment": "node",
-    "collectCoverage": true
+    "collectCoverage": true,
+    "collectCoverageFrom": [
+      "lib/**/*.js",
+      "!lib/module/plugin.js"
+    ]
   },
   "dependencies": {
     "@nuxtjs/axios": "^5.5.4",

--- a/test/fixtures/basic/nuxt.config.js
+++ b/test/fixtures/basic/nuxt.config.js
@@ -21,7 +21,10 @@ module.exports = {
       }
     }
   },
-  modules: ['@nuxtjs/axios', '@@'],
+  modules: [
+    '@nuxtjs/axios',
+    { handler: require('../../../') }
+  ],
   axios: {
     proxy: true
   },


### PR DESCRIPTION
It collects coverage from only `test/fixtures/basic/nuxt.config.js` in present.
It should collect from `lib` directory.