### PR TITLE
support client_secret at authorization code grant

### DIFF
--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -159,6 +159,7 @@ export default class Oauth2Scheme {
           redirect_uri: this._redirectURI,
           response_type: this.options.response_type,
           audience: this.options.audience,
+          client_secret: this.options.client_secret,
           grant_type: this.options.grant_type
         })
       })


### PR DESCRIPTION
To connect access_token_endpoint, Some servers require client_secret.
So add parameter "client_secret" at nuxt.config.js.