### PR TITLE
fix(core): set loggedIn after user

### DIFF
--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -249,8 +249,8 @@ export default class Auth {
   }
 
   setUser (user) {
-    this.$storage.setState('loggedIn', Boolean(user))
     this.$storage.setState('user', user)
+    this.$storage.setState('loggedIn', Boolean(user))
   }
 
   // ---------------------------------------------------------------


### PR DESCRIPTION
Usefull when subscribed to setLoggedIn mutation and want user object at that stage available