### PR TITLE
fix(oauth2): restore callback handling on static sites

### DIFF
--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -128,8 +128,8 @@ export default class Oauth2Scheme {
     if (this.$auth.options.redirect && this.$auth.ctx.route.path !== this.$auth.options.redirect.callback) {
       return
     }
-    // Callback flow is not supported in static generation
-    if (process.server && process.static) {
+    // Callback flow is not supported in server side
+    if (process.server) {
       return
     }
 


### PR DESCRIPTION
Fixes https://github.com/nuxt-community/auth-module/issues/299.
Fixes https://github.com/nuxt-community/auth-module/issues/452.

This fix works for my static Nuxt site, logging into Auth0.