### PR TITLE
Avoid rejecting promise from refresh token check

### DIFF
--- a/lib/schemes/refresh.js
+++ b/lib/schemes/refresh.js
@@ -213,7 +213,7 @@ export default class RefreshScheme extends LocalScheme {
               // Update Authorization header
               config.headers[this.options.tokenName] = this.$auth.getToken(this.name)
               return Promise.resolve(config)
-            }).catch(error => Promise.reject(error))
+            }).catch(error => this._logoutLocally())
           } else {
             this._logoutLocally()
           }


### PR DESCRIPTION
If we reject the promise from the refresh token api call, we will get the rejection from the original call. 
This rejection should be handled inside the module and disconnect the user as the refresh token failed.