### PR TITLE
feat(oauth2): Add support for runtime and environment-specific options

### DIFF
--- a/docs/schemes/oauth2.md
+++ b/docs/schemes/oauth2.md
@@ -86,3 +86,32 @@ By default is set to `refresh_token_key: 'refresh_token'`. It automatically stor
 By default is set to random generated string.
 
 The primary reason for using the state parameter is to mitigate CSRF attacks. ([read more](https://auth0.com/docs/protocols/oauth2/oauth-state))
+
+### `_runtimeOptions`
+
+`NOTE: Only available in univeral mode`
+
+
+By default all options are baked into the bundle during build. 
+If you use the same bundle in multiple environments (e.g. test and prod), but have options that are environment-specific,
+you can supply a function like this:
+
+```js
+auth: {
+  strategies: {
+    yourFavoriteProvider: {
+      _scheme: 'oauth2',
+      scope: ['openid', 'profile', 'email'],
+      _runtimeOptions: () => {
+        return {
+          client_id: process.env.CLIENT_ID,
+          authorization_endpoint: process.env.AUTH_URL + '/auth',
+          access_token_endpoint: process.env.AUTH_URL + '/token',
+          userinfo_endpoint: process.env.AUTH_URL + '/userinfo'
+        }
+      }
+    }
+  }
+}
+```
+The `_runtimeOptions` function  will be evaluated and merged with the other options during the initial request to the server.

--- a/lib/core/utilities.js
+++ b/lib/core/utilities.js
@@ -6,6 +6,11 @@ export const isSameURL = (a, b) => a.split('?')[0] === b.split('?')[0]
 export const isRelativeURL = u =>
   u && u.length && /^\/[a-zA-Z0-9@\-%_~][/a-zA-Z0-9@\-%_~]*[?]?([^#]*)#?([^#]*)$/.test(u)
 
+const isSpaMode = ctx => process.client && !ctx.nuxtState
+
+// eslint-disable-next-line
+const functionFromString = obj => Function('"use strict";return (' + obj + ')')()
+
 export const parseQuery = queryString => {
   const query = {}
   const pairs = queryString.split('&')
@@ -82,4 +87,34 @@ export function decodeValue (val) {
 
   // Return as is
   return val
+}
+
+export function handleRuntimeOptions (ctx, options) {
+  // _runtimeOptions is only supported in universal mode
+  if (isSpaMode(ctx)) {
+    if (options._runtimeOptions) {
+      // eslint-disable-next-line
+      console.error('[ERROR] [AUTH]: _runtimeOptions is only supported in universal mode.')
+    }
+    return {}
+  }
+
+  const key = 'auth._runtimeOptions.' + options._name
+
+  // Evaluate and share _runtimeOptions with client
+  if (process.server && options._runtimeOptions) {
+    const runtimeOptions = functionFromString(options._runtimeOptions)()
+
+    ctx.beforeNuxtRender(({ nuxtState }) => {
+      nuxtState[key] = runtimeOptions
+    })
+    return runtimeOptions
+  }
+
+  // Fetch shared _runtimeOptions from client side
+  if (process.client && ctx.nuxtState && ctx.nuxtState[key]) {
+    return ctx.nuxtState[key]
+  }
+
+  return {}
 }

--- a/lib/module/plugin.js
+++ b/lib/module/plugin.js
@@ -15,8 +15,16 @@ export default function (ctx, inject) {
   // Register strategies
   <%=
   options.strategies.map(strategy => {
+    function getSchemeOptions(schemeOptions) {
+      // _runtimeOptions function must be stringified (not supported by JSON.stringify)
+      if (schemeOptions._runtimeOptions) {
+        schemeOptions._runtimeOptions = schemeOptions._runtimeOptions.toString()
+      }
+      return JSON.stringify(schemeOptions)
+    }
+
     const scheme = 'scheme_' + hash(options.strategyScheme.get(strategy))
-    const schemeOptions = JSON.stringify(strategy)
+    const schemeOptions = getSchemeOptions(strategy)
     const name = strategy._name
     return `// ${name}\n  $auth.registerStrategy('${name}', new ${scheme}($auth, ${schemeOptions}))`
   }).join('\n\n  ')

--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -1,4 +1,4 @@
-import { encodeQuery, parseQuery } from '../utilities'
+import { encodeQuery, parseQuery, handleRuntimeOptions } from '../utilities'
 import nanoid from 'nanoid'
 const isHttps = process.server ? require('is-https') : null
 
@@ -14,7 +14,9 @@ export default class Oauth2Scheme {
     this.req = auth.ctx.req
     this.name = options._name
 
-    this.options = Object.assign({}, DEFAULTS, options)
+    const runtimeOptions = handleRuntimeOptions(auth.ctx, options)
+
+    this.options = Object.assign({}, DEFAULTS, options, runtimeOptions)
   }
 
   get _scope () {


### PR DESCRIPTION
### The problem
Currently all the scheme options are baked into the bundle during build. 
Because of this - you can't use the same bundle in multiple environments (e.g. test and prod) if you have options that are environment-specific.

#### Example use case
Some organisations have dedicated auth servers for each environment:
Prod: `login.example.com/oauth-path`
Test: `login-test.example.com/oauth-path`

The developers want to deploy the same bundle in all environments, and supply an environment variable `AUTH_URL` which points to the correct url.

The developers can't set `authorization_endpoint: process.env.AUTH_URL` in the options, because this variable is not known at build time.

### Proposed solution
To solve this issue, I propose we introduce a new option: `_runtimeOptions`, which is evaluated runtime:

```js
auth: {
  strategies: {
    yourFavoriteProvider: {
      _scheme: 'oauth2',
      scope: ['openid', 'profile', 'email'],
      _runtimeOptions: () => {
        return {
          client_id: process.env.CLIENT_ID,
          authorization_endpoint: process.env.AUTH_URL + '/auth',
          access_token_endpoint: process.env.AUTH_URL + '/token',
          userinfo_endpoint: process.env.AUTH_URL + '/userinfo'
        }
      }
    }
  }
}
```
The `_runtimeOptions` function  will be evaluated and merged with the other options during the initial request to the server.

#### Security concerns
I evaluated the risk of creating a function runtime (see [eval is evil](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#Do_not_ever_use_eval!)), but I think it should be fine, since we supply the string which is converted to a function at build time (see code). 

#### Alternative solution
If we can't do it this way, maybe we could supply a list of environment variable name mappings?:
```js
options: {
  _scheme: 'oauth2',
  _optionsFromEnvironment: {
    client_id: AUTH_CLIENT_ID,
    authorization_endpoint: AUTH_ENDPOINT,
    token_endpoint: AUTH_TOKEN_ENDPOINT
  }
}
```
i.e: `client_id` would be mapped to `process.env.AUTH_CLIENT_ID`

Although this method is less flexible, it does not rely on creating functions runtime.

### Caveats
- Only supported in universal mode (I think we can get around this, though)

### What about local scheme?
This feature is very easy to add for local schemes, but I could not come up with a use case, so I left it out. Please tell me if you have a use case and think it should be available for local schemes 🙂

What do you think about this proposal? 😄