### PR TITLE
docs: explain need to transpile nanoid for ie11 support

### DIFF
--- a/docs/guide/setup.md
+++ b/docs/guide/setup.md
@@ -28,3 +28,11 @@ auth: {
 ::: warning IMPORTANT
 When adding `auth-module` to a new Nuxt project ensure you have activated the Vuex store. More information on how to do that can be found on the [Nuxt Getting Started Guide](https://nuxtjs.org/guide/vuex-store).
 :::
+
+Finally, if you need IE11 support, you will need to transpile `nanoid`, a dependency of `@nuxtjs/auth`. Add the following to your `nuxt.config.js`:
+
+```js
+  build: {
+    transpile: [/^nanoid/]
+  },
+```


### PR DESCRIPTION
The current version of `nanoid` uses `Math.clz32` which is not supported by IE11. This documentation change explains the need to transpile `nanoid` for projects that need to support IE11.