### PR TITLE
feat: properly use initialState option so user can define their own

### DIFF
--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -18,7 +18,9 @@ export default class Auth {
     this._redirectListeners = []
 
     // Storage & State
-    options.initialState = { user: null, loggedIn: false }
+    if (!options.initialState) {
+      options.initialState = () => ({ user: null, loggedIn: false })
+    }
     const storage = new Storage(ctx, options)
 
     this.$storage = storage

--- a/lib/core/storage.js
+++ b/lib/core/storage.js
@@ -85,7 +85,7 @@ export default class Storage {
     if (this._useVuex) {
       const storeModule = {
         namespaced: true,
-        state: () => this.options.initialState,
+        state: () => this.options.initialState(this.ctx),
         mutations: {
           SET (state, payload) {
             Vue.set(state, payload.key, payload.value)
@@ -99,7 +99,7 @@ export default class Storage {
 
       this.state = this.ctx.store.state[this.options.vuex.namespace]
     } else {
-      Vue.set(this, 'state', {})
+      Vue.set(this, 'state', this.options.initialState(this.ctx))
     }
   }
 

--- a/lib/module/index.js
+++ b/lib/module/index.js
@@ -51,6 +51,11 @@ function validateOptions (options) {
   if (!this.options.store) {
     logger.fatal('Enable vuex store by creating `store/index.js`.')
   }
+
+  if (options.initialState && typeof options.initialState !== 'function') {
+    logger.error('Ignoring `initialState`, when provided it should be a function')
+    delete options.initialState
+  }
 }
 
 function copyCore (options) {

--- a/lib/module/plugin.js
+++ b/lib/module/plugin.js
@@ -9,7 +9,7 @@ export default function (ctx, inject) {
   // Options
   const options = <%= JSON.stringify(options.options) %>
   <% if (typeof options.options.initialState === 'function') { %>
-  options.initialState = <%= serializeFunction(options.options.initialState).replace(/^\s+cov_[^\s]+;\s*$/mgi, '') %>
+  options.initialState = <%= serializeFunction(options.options.initialState) %>
   <% } %>
 
   // Create a new Auth instance

--- a/lib/module/plugin.js
+++ b/lib/module/plugin.js
@@ -8,6 +8,9 @@ import './middleware'
 export default function (ctx, inject) {
   // Options
   const options = <%= JSON.stringify(options.options) %>
+  <% if (typeof options.options.initialState === 'function') { %>
+  options.initialState = <%= serializeFunction(options.options.initialState).replace(/^\s+cov_[^\s]+;\s*$/mgi, '') %>
+  <% } %>
 
   // Create a new Auth instance
   const $auth = new Auth(ctx, options)

--- a/test/fixtures/basic/nuxt.config.js
+++ b/test/fixtures/basic/nuxt.config.js
@@ -6,6 +6,7 @@ module.exports = {
   srcDir: __dirname,
   serverMiddleware: ['@@/examples/api/auth'],
   auth: {
+    /* istanbul ignore next */
     initialState () {
       return {
         user: null,

--- a/test/fixtures/basic/nuxt.config.js
+++ b/test/fixtures/basic/nuxt.config.js
@@ -6,6 +6,13 @@ module.exports = {
   srcDir: __dirname,
   serverMiddleware: ['@@/examples/api/auth'],
   auth: {
+    initialState () {
+      return {
+        user: null,
+        loggedIn: false,
+        customStateOption: 'test'
+      }
+    },
     plugins: [
       '~/plugins/auth.js'
     ],

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -30,7 +30,7 @@ describe('auth', () => {
     await page.goto(url('/'))
 
     const state = await page.evaluate(() => window.__NUXT__.state)
-    expect(state.auth).toEqual({ user: null, loggedIn: false, strategy: 'local' })
+    expect(state.auth).toEqual({ user: null, loggedIn: false, customStateOption: 'test', strategy: 'local' })
 
     await page.close()
   })


### PR DESCRIPTION
I'd like to use nuxt-auth with vue-stator but that means I need to be able to inject the vue-stator state into nuxt-auth. This pr makes that possible by having the user provide an initialState function in the module options. This function receives the nuxt context as first & only argument