### PR TITLE
fix(core): support querystring only url for `isRelativeURL`

### DIFF
--- a/lib/core/utilities.js
+++ b/lib/core/utilities.js
@@ -4,7 +4,7 @@ export const isSet = o => !isUnset(o)
 export const isSameURL = (a, b) => a.split('?')[0] === b.split('?')[0]
 
 export const isRelativeURL = u =>
-  u && u.length && /^\/[a-zA-Z0-9@\-%_~][/a-zA-Z0-9@\-%_~]*[?]?([^#]*)#?([^#]*)$/.test(u)
+  u && u.length && /^\/([a-zA-Z0-9@\-%_~][/a-zA-Z0-9@\-%_~]*)?([?][^#]*)?(#[^#]*)?$/.test(u)
 
 export const parseQuery = queryString => {
   const query = {}


### PR DESCRIPTION
Currently, the `isRelativeURL` regex returns false for urls with only querystring or hash part.
- `/?query=foo`
- `/#bar`.

This prevents redirection to those urls in the auth callback.

This PR fixes the issue.