### PR TITLE
hasScope() supports scopeKeys containing dots

### DIFF
--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -386,7 +386,10 @@ export default class Auth {
   }
 
   hasScope (scope) {
-    const userScopes = this.$state.user && getProp(this.$state.user, this.options.scopeKey) ? getProp(this.$state.user, this.options.scopeKey) : this.$state.user[this.options.scopeKey]
+    const userScopes =
+      this.$state.user && getProp(this.$state.user, this.options.scopeKey)
+        ? getProp(this.$state.user, this.options.scopeKey)
+        : this.$state.user && this.$state.user[this.options.scopeKey]
 
     if (!userScopes) {
       return undefined

--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -386,7 +386,7 @@ export default class Auth {
   }
 
   hasScope (scope) {
-    const userScopes = this.$state.user && getProp(this.$state.user, this.options.scopeKey)
+    const userScopes = this.$state.user && getProp(this.$state.user, this.options.scopeKey) ? getProp(this.$state.user, this.options.scopeKey) : this.$state.user[this.options.scopeKey]
 
     if (!userScopes) {
       return undefined


### PR DESCRIPTION
Fix for issue #500 - If user scopes return falsey (due to inappropriate dot-notation interpretation), fall back to getting scopes from the user object root. 

hasScope() now supports scopeKeys which contain dots, for example keys which are namespaced using url-style keys.