### PR TITLE
fix(module): don't log fatal error when vuex is disabled

### DIFF
--- a/lib/module/index.js
+++ b/lib/module/index.js
@@ -48,7 +48,7 @@ function validateOptions (options) {
   }
 
   // Enforce vuex store because auth depends on it
-  if (!this.options.store) {
+  if (options.vuex && !this.options.store) {
     logger.fatal('Enable vuex store by creating `store/index.js`.')
   }
 }


### PR DESCRIPTION
This would already help me fixing my issues using nuxt-auth with vue-stator

For laughs, this is what i do now to fix this:
```js
buildModules: [
    async function fixNuxtAuth() {
      const authModulePath = require.resolve('@nuxtjs/auth/lib/module/index.js')
      const haystack = await fs.readFileSync(authModulePath, { encoding: 'utf8' })

      const needle = 'if (!this.options.store) {'
      const fixed = 'if (options.vuex && !this.options.store) {'

      if (!haystack.includes(needle)) {
        if (!haystack.includes(fixed)) {
          consola.error(`fix-nuxt-auth: needle & fixed both not found in haystack`)
        }
        return
      }

      const content = haystack.replace(needle, fixed)
      await fs.writeFile(authModulePath, content)
    },
```