### PR TITLE
Fix #275

### DIFF
--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -5,6 +5,7 @@ export default class Auth {
   constructor (ctx, options) {
     this.ctx = ctx
     this.options = options
+    this._baseUrl = getProp(options, 'redirect.base') || ''
 
     // Strategies
     this.strategies = {}
@@ -369,7 +370,7 @@ export default class Auth {
 
     if (process.client) {
       if (noRouter) {
-        window.location.replace(to)
+        window.location.replace(this._baseUrl + to)
       } else {
         this.ctx.redirect(to, this.ctx.query)
       }

--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -33,11 +33,11 @@ export default class Oauth2Scheme {
     if (process.server && this.req) {
       const protocol = 'http' + (isHttps(this.req) ? 's' : '') + '://'
 
-      return protocol + this.req.headers.host + this.$auth.options.redirect.callback
+      return protocol + this.req.headers.host + this.$auth._baseUrl + this.$auth.options.redirect.callback
     }
 
     if (process.client) {
-      return window.location.origin + this.$auth.options.redirect.callback
+      return window.location.origin + this.$auth._baseUrl + this.$auth.options.redirect.callback
     }
   }
 


### PR DESCRIPTION
A clean, minimal but somewhat incomplete fix for #275.

As per this, we need to specify the base path ( ie, `router.base` ) in the configuration section of auth middleware.
Ie, the configuration `auth.redirect.base` should hold the same value as that of `router.base`

I don't know how to automate this. But this solution will work if we add that config.

Please note that, this fix will not break any existing functionality because, we are using safe default values for this new config option


Signed-off-by: Harish Karumuthil <harish2704@gmail.com>