### PR TITLE
fix: fix `setUserToken` issues

### DIFF
--- a/lib/schemes/local.js
+++ b/lib/schemes/local.js
@@ -55,17 +55,11 @@ export default class LocalScheme {
   }
 
   async setUserToken (tokenValue) {
-    // Ditch any leftover local tokens before attempting to log in
-    await this._logoutLocally()
-
-    if (this.options.tokenRequired) {
-      const token = this.options.tokenType
-        ? this.options.tokenType + ' ' + tokenValue
-        : tokenValue
-
-      this.$auth.setToken(this.name, token)
-      this._setToken(token)
-    }
+    const token = this.options.tokenType
+      ? this.options.tokenType + ' ' + tokenValue
+      : tokenValue
+    this.$auth.setToken(this.name, token)
+    this._setToken(token)
 
     return this.fetchUser()
   }


### PR DESCRIPTION
this PR was created to fix issues that were found with the original merge from [PR 278](https://github.com/nuxt-community/auth-module/pull/278)

- remove the logging out as we will overwrite the token anyways and it introduced unexpected and unwanted behaviour
- remove check if we need to use token. this functions purpose is to set the token, so we will always do it