### PR TITLE
Added "removeUniversal" to storage.md

### DIFF
--- a/docs/api/storage.md
+++ b/docs/api/storage.md
@@ -12,6 +12,7 @@ Universally keep state in vuex, localStorage and Cookies:
 this.$auth.$storage.setUniversal(key, val, isJson)
 this.$auth.$storage.getUniversal(key, isJson)
 this.$auth.$storage.syncUniversal(key, defaultValue, isJson)
+this.$auth.$storage.removeUniversal(key)
 ```
 
 ## Local State


### PR DESCRIPTION
Just crawled through the source code and recognized that the "removeUniversal" method is not mentioned in the doc. It's kind of useful