### PR TITLE
fix: remove the trailing slash of paths in `isSameURL`

### DIFF
--- a/lib/core/utilities.js
+++ b/lib/core/utilities.js
@@ -1,7 +1,7 @@
 export const isUnset = o => typeof o === 'undefined' || o === null
 export const isSet = o => !isUnset(o)
 
-export const isSameURL = (a, b) => a.split('?')[0].replace(/\/+$/,'') === b.split('?')[0].replace(/\/+$/,'')
+export const isSameURL = (a, b) => a.split('?')[0].replace(/\/+$/, '') === b.split('?')[0].replace(/\/+$/, '')
 
 export const isRelativeURL = u =>
   u && u.length && /^\/([a-zA-Z0-9@\-%_~][/a-zA-Z0-9@\-%_~]*)?([?][^#]*)?(#[^#]*)?$/.test(u)

--- a/lib/core/utilities.js
+++ b/lib/core/utilities.js
@@ -1,7 +1,7 @@
 export const isUnset = o => typeof o === 'undefined' || o === null
 export const isSet = o => !isUnset(o)
 
-export const isSameURL = (a, b) => a.split('?')[0] === b.split('?')[0]
+export const isSameURL = (a, b) => a.split('?')[0].replace(/\/+$/,'') === b.split('?')[0].replace(/\/+$/,'')
 
 export const isRelativeURL = u =>
   u && u.length && /^\/([a-zA-Z0-9@\-%_~][/a-zA-Z0-9@\-%_~]*)?([?][^#]*)?(#[^#]*)?$/.test(u)


### PR DESCRIPTION
Comparing URLs in isSameURL should remove the trailing slash.
Comparison of `https://example.com/signIn` with `https://example.com/signIn/` should return true.