### PR TITLE
fix: clear tokens when calling `$auth.reset()`

### DIFF
--- a/lib/schemes/local.js
+++ b/lib/schemes/local.js
@@ -35,7 +35,7 @@ export default class LocalScheme {
     }
 
     // Ditch any leftover local tokens before attempting to log in
-    await this.reset()
+    await this.$auth.reset()
 
     const result = await this.$auth.request(
       endpoint,
@@ -93,8 +93,8 @@ export default class LocalScheme {
         .catch(() => { })
     }
 
-    // But logout locally regardless
-    return this.reset()
+    // But reset regardless
+    return this.$auth.reset()
   }
 
   async reset () {

--- a/lib/schemes/local.js
+++ b/lib/schemes/local.js
@@ -35,7 +35,7 @@ export default class LocalScheme {
     }
 
     // Ditch any leftover local tokens before attempting to log in
-    await this._logoutLocally()
+    await this.reset()
 
     const result = await this.$auth.request(
       endpoint,
@@ -94,15 +94,19 @@ export default class LocalScheme {
     }
 
     // But logout locally regardless
-    return this._logoutLocally()
+    return this.reset()
   }
 
-  async _logoutLocally () {
+  async reset () {
     if (this.options.tokenRequired) {
       this._clearToken()
     }
 
-    return this.$auth.reset()
+    this.$auth.setUser(false)
+    this.$auth.setToken(this.name, false)
+    this.$auth.setRefreshToken(this.name, false)
+
+    return Promise.resolve()
   }
 }
 

--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -67,9 +67,14 @@ export default class Oauth2Scheme {
     this.$auth.ctx.app.$axios.setHeader(this.options.tokenName, false)
   }
 
-  async logout () {
+  async reset () {
     this._clearToken()
-    return this.$auth.reset()
+
+    this.$auth.setUser(false)
+    this.$auth.setToken(this.name, false)
+    this.$auth.setRefreshToken(this.name, false)
+
+    return Promise.resolve()
   }
 
   login ({ params, state, nonce } = {}) {


### PR DESCRIPTION
The purpose of this PR is refactor the methods `logoutLocally` of `local` scheme and `logout` of `oauth2` scheme. 
By now they are clearing the tokens and calling `$auth.reset()`, but with these changes they will be the `reset` method. That way, whenever `$auth.reset()` is called (e.g. when `resetOnError` is `true`) it will reset properly.

This closes #172 