### PR TITLE
feat(core): support getting response with `requestWith` utility

### DIFF
--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -295,7 +295,7 @@ export default class Auth {
       })
   }
 
-  requestWith (strategy, endpoint, defaults) {
+  requestWith (strategy, endpoint, defaults, withResponse) {
     const token = this.getToken(strategy)
 
     const _endpoint = Object.assign({}, defaults, endpoint)
@@ -308,7 +308,7 @@ export default class Auth {
       _endpoint.headers[tokenName] = token
     }
 
-    return this.request(_endpoint)
+    return this.request(_endpoint, false, withResponse)
   }
 
   wrapLogin (promise) {


### PR DESCRIPTION
This PR allow `requestWith` to return response.

This fix is required to return response from [refreshToken method](https://github.com/nuxt-community/auth-module/blob/feat/refresh/lib/schemes/refresh.js#L145) of #361 