### PR TITLE
test(logout): fix token properties and expect `logoutToken` to be `false`

### DIFF
--- a/test/module.test.js
+++ b/test/module.test.js
@@ -76,7 +76,7 @@ describe('auth', () => {
 
       return {
         loginAxiosBearer: window.$nuxt.$axios.defaults.headers.common.Authorization,
-        loginToken: window.$nuxt.$auth.getToken()
+        loginToken: window.$nuxt.$auth.getToken('local')
       }
     })
 
@@ -88,11 +88,11 @@ describe('auth', () => {
 
       return {
         logoutAxiosBearer: window.$nuxt.$axios.defaults.headers.common.Authorization,
-        logoutToken: window.$nuxt.$auth.getToken()
+        logoutToken: window.$nuxt.$auth.getToken('local')
       }
     })
 
-    expect(logoutToken).toBeNull()
+    expect(logoutToken).toBeFalsy()
     expect(logoutAxiosBearer).toBeUndefined()
 
     await page.close()


### PR DESCRIPTION
This PR fix the `logout` test. 

It will fix the value of  `loginToken` and `logoutToken` properties and expect `logoutToken` to be `false` instead of `null`