### PR TITLE
docs: fix typo in links

### DIFF
--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -1,6 +1,6 @@
 # auth
 
-[Source Code](https://github.com/nuxt-community/auth-module/blob/masterlib/core/auth.js)
+[Source Code](https://github.com/nuxt-community/auth-module/blob/master/lib/core/auth.js)
 
 This module globally injects `$auth` instance, meaning that you can access it anywhere using `this.$auth`.
 For plugins, asyncData, fetch, nuxtServerInit and Middleware, you can access it from `context.$auth`.

--- a/docs/api/storage.md
+++ b/docs/api/storage.md
@@ -1,6 +1,6 @@
 # storage
 
-[Source Code](https://github.com/nuxt-community/auth-module/blob/masterlib/core/storage.js)
+[Source Code](https://github.com/nuxt-community/auth-module/blob/master/lib/core/storage.js)
 
 Auth module has a built-in powerful and universal storage to keep tokens and profile data.
 

--- a/docs/providers/auth0.md
+++ b/docs/providers/auth0.md
@@ -1,6 +1,6 @@
 # Auth0
 
-[Source Code](https://github.com/nuxt-community/auth-module/blob/masterlib/providers/auth0.js)
+[Source Code](https://github.com/nuxt-community/auth-module/blob/master/lib/providers/auth0.js)
 
 [Auth0](https://auth0.com) is a great authentication-as-a-service platform for free!
 

--- a/docs/providers/facebook.md
+++ b/docs/providers/facebook.md
@@ -1,6 +1,6 @@
 # Facebook
 
-[Source Code](https://github.com/nuxt-community/auth-module/blob/masterlib/providers/facebook.js)
+[Source Code](https://github.com/nuxt-community/auth-module/blob/master/lib/providers/facebook.js)
 
 ## Usage
 

--- a/docs/providers/github.md
+++ b/docs/providers/github.md
@@ -1,6 +1,6 @@
 # GitHub
 
-[Source Code](https://github.com/nuxt-community/auth-module/blob/masterlib/providers/github.js)
+[Source Code](https://github.com/nuxt-community/auth-module/blob/master/lib/providers/github.js)
 
 ## Usage
 

--- a/docs/providers/google.md
+++ b/docs/providers/google.md
@@ -4,7 +4,7 @@ sidebarDepth: 0
 
 # Google
 
-[Source Code](https://github.com/nuxt-community/auth-module/blob/masterlib/providers/google.js)
+[Source Code](https://github.com/nuxt-community/auth-module/blob/master/lib/providers/google.js)
 
 ## Usage
 

--- a/docs/providers/laravel-passport.md
+++ b/docs/providers/laravel-passport.md
@@ -1,6 +1,6 @@
 # Laravel Passport
 
-[Source Code](https://github.com/nuxt-community/auth-module/blob/masterlib/providers/laravel.passport.js)
+[Source Code](https://github.com/nuxt-community/auth-module/blob/master/lib/providers/laravel.passport.js)
 
 ## Usage
 

--- a/docs/schemes/local.md
+++ b/docs/schemes/local.md
@@ -1,6 +1,6 @@
 # Local
 
-[Source Code](https://github.com/nuxt-community/auth-module/blob/masterlib/schemes/local.js)
+[Source Code](https://github.com/nuxt-community/auth-module/blob/master/lib/schemes/local.js)
 
 `local` is the default, general purpose authentication scheme, supporting `Cookie` and `JWT` login flows.
 

--- a/docs/schemes/oauth2.md
+++ b/docs/schemes/oauth2.md
@@ -1,6 +1,6 @@
 # Oauth2
 
-[Source Code](https://github.com/nuxt-community/auth-module/blob/masterlib/schemes/oauth2.js)
+[Source Code](https://github.com/nuxt-community/auth-module/blob/master/lib/schemes/oauth2.js)
 
 `oauth2` supports various oauth2 login flows. There are many pre-configured providers like [auth0](../providers/auth0.md) that you may use instead of directly using this scheme.
 


### PR DESCRIPTION
Commit 6af5b0f78c2d067cd020f13bd9a7c6c040942688 introduced a typo in a few links (a `/` is missing)