### PR TITLE
feat(core): add `loggedIn` class

### DIFF
--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -28,7 +28,7 @@ This boolean flag indicates that user is authenticated and available at the mome
 
 ```js
 // Access using $auth
-this.$auth.loggedIn
+this.$auth.check
 
 // Access using vuex
 this.$store.state.auth.loggedIn

--- a/docs/recipes/extend.md
+++ b/docs/recipes/extend.md
@@ -19,7 +19,7 @@ If you have plugins that need to access `$auth`, you can use `auth.plugins` opti
 
 ```js
 export default function ({ $auth }) {
-  if (!$auth.loggedIn) {
+  if (!$auth.check) {
     return
   }
 

--- a/examples/demo/layouts/default.vue
+++ b/examples/demo/layouts/default.vue
@@ -12,7 +12,7 @@
           <b-nav-item to="/oauth2RefreshTest">Oauth2 token refresh test</b-nav-item>
         </b-navbar-nav>
         <b-navbar-nav class="ml-auto">
-          <template v-if="$auth.$state.loggedIn">
+          <template v-if="$auth.check">
             <b-nav-item-dropdown :text="$auth.user.name" right>
               <b-dropdown-item @click="$auth.logout()">Logout</b-dropdown-item>
             </b-nav-item-dropdown>

--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -2,6 +2,7 @@ import Storage from './storage'
 import { routeOption, isRelativeURL, isSet, isSameURL, getProp } from './utilities'
 import Token from './token'
 import RefreshToken from './refreshToken'
+import LoggedIn from './LoggedIn'
 
 export default class Auth {
   constructor (ctx, options) {
@@ -27,6 +28,9 @@ export default class Auth {
     // Token & Refresh Token
     this.token = new Token(this)
     this.refreshToken = new RefreshToken(this)
+
+    // Logged In
+    this.loggedIn = new LoggedIn(this)
   }
 
   async init () {
@@ -53,6 +57,14 @@ export default class Auth {
     }
 
     try {
+      // Sync logged in state
+      const loggedIn = this.loggedIn.sync()
+
+      // Force logged in state to be false if undefined
+      if (loggedIn === undefined) {
+        this.loggedIn.set(false)
+      }
+
       // Call mounted for active strategy on initial load
       await this.mounted()
     } catch (error) {
@@ -74,7 +86,7 @@ export default class Auth {
     if (!this._state_warn_shown) {
       this._state_warn_shown = true
       // eslint-disable-next-line no-console
-      console.warn('[AUTH] $auth.state is deprecated. Please use $auth.$state or top level props like $auth.loggedIn')
+      console.warn('[AUTH] $auth.state is deprecated. Please use $auth.$state or top level props like $auth.check')
     }
 
     return this.$state
@@ -84,7 +96,7 @@ export default class Auth {
     if (!this._get_state_warn_shown) {
       this._get_state_warn_shown = true
       // eslint-disable-next-line no-console
-      console.warn('[AUTH] $auth.getState is deprecated. Please use $auth.$storage.getState() or top level props like $auth.loggedIn')
+      console.warn('[AUTH] $auth.getState is deprecated. Please use $auth.$storage.getState() or top level props like $auth.check')
     }
 
     return this.$storage.getState(key)
@@ -178,6 +190,7 @@ export default class Auth {
 
   reset () {
     if (!this.strategy.reset) {
+      this.loggedIn.set(false)
       this.setUser(false)
       this.token.reset()
       this.refreshToken.reset()
@@ -209,7 +222,7 @@ export default class Auth {
     return this.$state.user
   }
 
-  get loggedIn () {
+  get check () {
     return this.$state.loggedIn
   }
 
@@ -222,7 +235,6 @@ export default class Auth {
 
   setUser (user) {
     this.$storage.setState('user', user)
-    this.$storage.setState('loggedIn', Boolean(user))
   }
 
   // ---------------------------------------------------------------

--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -2,7 +2,7 @@ import Storage from './storage'
 import { routeOption, isRelativeURL, isSet, isSameURL, getProp } from './utilities'
 import Token from './token'
 import RefreshToken from './refreshToken'
-import LoggedIn from './LoggedIn'
+import LoggedIn from './loggedIn'
 
 export default class Auth {
   constructor (ctx, options) {

--- a/lib/core/loggedIn.js
+++ b/lib/core/loggedIn.js
@@ -1,0 +1,37 @@
+export default class LoggedIn {
+  constructor (auth) {
+    this.$auth = auth
+  }
+
+  _setLoggedIn (loggedIn) {
+    const _key = this.$auth.options.loggedIn.prefix + this.$auth.strategy.name
+
+    return this.$auth.$storage.setUniversal(_key, loggedIn)
+  }
+
+  _syncLoggedIn () {
+    const _key = this.$auth.options.loggedIn.prefix + this.$auth.strategy.name
+
+    return this.$auth.$storage.syncUniversal(_key)
+  }
+
+  get () {
+    const _key = this.$auth.options.loggedIn.prefix + this.$auth.strategy.name
+
+    return this.$auth.$storage.getUniversal(_key)
+  }
+
+  set (loggedIn) {
+    this._setLoggedIn(loggedIn)
+    this.$auth.$storage.setState('loggedIn', loggedIn)
+
+    return loggedIn
+  }
+
+  sync () {
+    const loggedIn = this._syncLoggedIn()
+    this.$auth.$storage.setState('loggedIn', loggedIn)
+
+    return loggedIn
+  }
+}

--- a/lib/module/defaults.js
+++ b/lib/module/defaults.js
@@ -63,6 +63,12 @@ module.exports = {
     prefix: '_refresh_token_expiration.'
   },
 
+  // -- Logged in --
+
+  loggedIn: {
+    prefix: '_logged_in.'
+  },
+
   // -- Strategies --
 
   defaultStrategy: undefined /* will be auto set at module level */,

--- a/lib/schemes/local.js
+++ b/lib/schemes/local.js
@@ -57,7 +57,10 @@ export default class LocalScheme {
       this.options.endpoints.login
     )
 
-    // Update Token
+    // Update logged in state
+    this.$auth.loggedIn.set(true)
+
+    // Update token
     if (this.options.token.required) {
       this.$auth.token.set(getProp(data, this.options.token.property))
     }
@@ -83,6 +86,11 @@ export default class LocalScheme {
   }
 
   async fetchUser (endpoint) {
+    // User not logged in
+    if (!this.$auth.loggedIn.get()) {
+      return
+    }
+
     // Token is required but not available
     if (this.options.token.required && !this.$auth.token.get()) {
       return
@@ -125,6 +133,7 @@ export default class LocalScheme {
   }
 
   async reset () {
+    this.$auth.loggedIn.set(false)
     this._setClientId(false)
     this.$auth.setUser(false)
     this.$auth.token.reset()

--- a/lib/schemes/refresh.js
+++ b/lib/schemes/refresh.js
@@ -40,7 +40,7 @@ export default class RefreshScheme extends LocalScheme {
     // Fetch user once
     return this.$auth.fetchUserOnce().then(() => {
       // Only refresh token if user is logged in and is client side
-      if (process.client && this.$auth.loggedIn && this.options.autoRefresh) {
+      if (process.client && this.$auth.check && this.options.autoRefresh) {
         this.refreshController.handleRefresh()
           // Initialize scheduled refresh
           .then(() => this.refreshController.initializeScheduledRefresh())
@@ -60,6 +60,9 @@ export default class RefreshScheme extends LocalScheme {
       endpoint,
       this.options.endpoints.login
     )
+
+    // Update logged in state
+    this.$auth.loggedIn.set(true)
 
     // Update tokens
     this.$auth.token.set(getProp(data, this.options.token.property))
@@ -84,6 +87,11 @@ export default class RefreshScheme extends LocalScheme {
   }
 
   async fetchUser (endpoint) {
+    // User not logged in
+    if (!this.$auth.loggedIn.get()) {
+      return
+    }
+
     // Token is required but not available
     if (!this.$auth.token.get()) return
 
@@ -172,6 +180,7 @@ export default class RefreshScheme extends LocalScheme {
   }
 
   async reset () {
+    this.$auth.loggedIn.set(false)
     this._setClientId(false)
     this.$auth.setUser(false)
     this.$auth.token.reset()

--- a/test/fixtures/basic/pages/index.vue
+++ b/test/fixtures/basic/pages/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <pre v-if="$auth.loggedIn" v-html="$auth.user"></pre>
+    <pre v-if="$auth.check" v-html="$auth.user"></pre>
     <div v-else>Please login</div>
   </div>
 </template>


### PR DESCRIPTION
The goal is to avoid the fetch user request when the user is not logged.

I improved the logged in state adding its own class with `get`, `set` and `sync` methods. This way `loggedIn` is no longer based on `user` object. Solving issues related to cookie based overflow.

`LoggedIn` class can be accessed using `$auth.loggedIn`:
`$auth.loggedIn.get()`, `$auth.loggedIn.set()` and `$auth.loggedIn.sync()`

I renamed the old method `loggedIn` to `check` to avoid conflict. So we can use `$auth.check` to check if user is logged in or not.

This closes #550 and closes #321