### PR TITLE
feat: laravel sanctum support

### DIFF
--- a/lib/module/index.js
+++ b/lib/module/index.js
@@ -157,10 +157,10 @@ function processStrategies (options) {
         src: schemeSrc.replace('refresh.js', 'local.js'),
         fileName: join('auth', 'schemes', schemeName.replace('refresh.js', 'local.js'))
       })
-    } else if (schemeName === 'laravel.airlock.js') {
+    } else if (schemeName === 'laravel.sanctum.js') {
       this.addTemplate({
-        src: schemeSrc.replace('laravel.airlock.js', 'local.js'),
-        fileName: join('auth', 'schemes', schemeName.replace('laravel.airlock.js', 'local.js'))
+        src: schemeSrc.replace('laravel.sanctum.js', 'local.js'),
+        fileName: join('auth', 'schemes', schemeName.replace('laravel.sanctum.js', 'local.js'))
       })
     }
 

--- a/lib/module/index.js
+++ b/lib/module/index.js
@@ -157,6 +157,11 @@ function processStrategies (options) {
         src: schemeSrc.replace('refresh.js', 'local.js'),
         fileName: join('auth', 'schemes', schemeName.replace('refresh.js', 'local.js'))
       })
+    } else if (schemeName === 'laravel.airlock.js') {
+      this.addTemplate({
+        src: schemeSrc.replace('laravel.airlock.js', 'local.js'),
+        fileName: join('auth', 'schemes', schemeName.replace('laravel.airlock.js', 'local.js'))
+      })
     }
 
     // Remove unnecessary fields

--- a/lib/schemes/laravel.airlock.js
+++ b/lib/schemes/laravel.airlock.js
@@ -7,7 +7,7 @@ export default class LaravelAirlockScheme extends LocalScheme {
   }
 
   async login (endpoint) {
-    await this.$auth.request(this.options.endpoints.airlockCRSF)
+    await this.$auth.request(this.options.endpoints.airlockCSRF)
 
     return super.login(endpoint)
   }
@@ -16,7 +16,7 @@ export default class LaravelAirlockScheme extends LocalScheme {
 const DEFAULTS = {
   _name: 'laravel.airlock',
   endpoints: {
-    airlockCRSF: {
+    airlockCSRF: {
       url: '/airlock/csrf-cookie',
       method: 'get',
       headers: {

--- a/lib/schemes/laravel.airlock.js
+++ b/lib/schemes/laravel.airlock.js
@@ -1,0 +1,57 @@
+import LocalScheme from './local'
+import defu from 'defu'
+
+export default class LaravelAirlockScheme extends LocalScheme {
+  constructor (auth, options) {
+    super(auth, defu(options, DEFAULTS))
+  }
+
+  async login (endpoint) {
+    await this.$auth.request(this.options.endpoints.airlockCRSF)
+
+    return super.login(endpoint)
+  }
+}
+
+const DEFAULTS = {
+  _name: 'laravel.airlock',
+  endpoints: {
+    airlockCRSF: {
+      url: '/airlock/csrf-cookie',
+      method: 'get',
+      headers: {
+        'X-Requested-With': 'XMLHttpRequest'
+      },
+      withCredentials: true
+    },
+    login: {
+      headers: {
+        'X-Requested-With': 'XMLHttpRequest',
+        'Content-Type': 'application/json'
+      },
+      withCredentials: true
+    },
+    logout: {
+      headers: {
+        'X-Requested-With': 'XMLHttpRequest',
+        'Content-Type': 'application/json'
+      },
+      withCredentials: true
+    },
+    user: {
+      headers: {
+        'X-Requested-With': 'XMLHttpRequest',
+        'Content-Type': 'application/json'
+      },
+      withCredentials: true
+    }
+  },
+  token: {
+    type: false,
+    required: false
+  },
+  user: {
+    property: false
+  },
+  clientId: false
+}

--- a/lib/schemes/laravel.sanctum.js
+++ b/lib/schemes/laravel.sanctum.js
@@ -1,23 +1,23 @@
 import LocalScheme from './local'
 import defu from 'defu'
 
-export default class LaravelAirlockScheme extends LocalScheme {
+export default class LaravelSanctumScheme extends LocalScheme {
   constructor (auth, options) {
     super(auth, defu(options, DEFAULTS))
   }
 
   async login (endpoint) {
-    await this.$auth.request(this.options.endpoints.airlockCSRF)
+    await this.$auth.request(this.options.endpoints.sanctumCSRF)
 
     return super.login(endpoint)
   }
 }
 
 const DEFAULTS = {
-  _name: 'laravel.airlock',
+  _name: 'laravel.sanctum',
   endpoints: {
-    airlockCSRF: {
-      url: '/airlock/csrf-cookie',
+    sanctumCSRF: {
+      url: '/sanctum/csrf-cookie',
       method: 'get',
       headers: {
         'X-Requested-With': 'XMLHttpRequest'


### PR DESCRIPTION
Add support to Laravel Sanctum.

I couldn't create it in a provider since Laravel Sanctum requires a `get` request to `/sanctum/csrf-cookie`  before attempting to login. So I extended `local` scheme.

This PR requires #556 to work properly.