### PR TITLE
fix(oauth2): correctly set `refreshToken`

### DIFF
--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -187,11 +187,11 @@ export default class Oauth2Scheme {
     }
 
     // Set token
-    this.$auth.token.set(token, this.options.token.type)
+    this.$auth.token.set(token)
 
     // Store refresh token
     if (refreshToken && refreshToken.length) {
-      this.$auth.refreshToken.set(token, this.options.token.type)
+      this.$auth.refreshToken.set(refreshToken)
     }
 
     // Redirect to home


### PR DESCRIPTION
Fixes issue where the access token and expiration are stored as the refresh token and expiration.

This closes #562 