### PR TITLE
docs: add `setUser` documentation

### DIFF
--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -63,6 +63,16 @@ this.$auth.login(/* .... */)
   .then(() => this.$toast.success('Logged In!'))
 ```
 
+### `setUser(user)`
+
+Set user data and update `loggedIn` state.
+
+> **TIP:** This function can be used to set the user using the login response after a successfully login, when [autoFetchUser](../schemes/local.md#autofetchuser) is disabled.
+
+```js
+await this.$auth.setUser(user)
+```
+
 ### `setUserToken(token)`
 
 - Returns: `Promise`

--- a/docs/schemes/local.md
+++ b/docs/schemes/local.md
@@ -123,4 +123,6 @@ This option can be used to disable all token handling. Useful for Cookie only fl
 
  - Default: `true`
 
- This option can be used to disable user fetch after login. It is useful when your login response already have the user.
+ This option can be used to disable user fetch after login.
+ 
+ > TIP: It is useful when your login response already have the user. To manually set the user, use [setUser](../api/auth.md#setuser-user).


### PR DESCRIPTION
This PR add `setUser` documentation. `setUser` is required to manually set the user when `autoFetchUser` is disabled.