### PR TITLE
docs(auth): remove `await` from `setUser` example

### DIFF
--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -70,7 +70,7 @@ Set user data and update `loggedIn` state.
 > **TIP:** This function can be used to set the user using the login response after a successfully login, when [autoFetchUser](../schemes/local.md#autofetchuser) is disabled.
 
 ```js
-await this.$auth.setUser(user)
+this.$auth.setUser(user)
 ```
 
 ### `setUserToken(token)`


### PR DESCRIPTION
I accidentally added `await` to `setUser` example. This PR will remove it.