### PR TITLE
fix(oauth2, refresh): only update refresh token if defined in response

### DIFF
--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -230,9 +230,15 @@ export default class Oauth2Scheme {
       })
     }, false, true)
 
+    const newToken = data[this.options.token.property]
+    const newRefreshToken = data[this.options.refreshToken.property]
+
     // Update tokens
-    this.$auth.token.set(data[this.options.token.property])
-    this.$auth.refreshToken.set(data[this.options.refreshToken.property])
+    this.$auth.token.set(newToken)
+
+    if (newRefreshToken) {
+      this.$auth.refreshToken.set(newRefreshToken)
+    }
 
     return response
   }

--- a/lib/schemes/refresh.js
+++ b/lib/schemes/refresh.js
@@ -155,9 +155,15 @@ export default class RefreshScheme extends LocalScheme {
       this.options.endpoints.refresh,
       true
     ).then(({ response, data }) => {
+      const token = getProp(data, this.options.token.property)
+      const refreshToken = getProp(data, this.options.refreshToken.property)
+
       // Update tokens
-      this.$auth.token.set(getProp(data, this.options.token.property))
-      this.$auth.refreshToken.set(getProp(data, this.options.refreshToken.property))
+      this.$auth.token.set(token)
+
+      if (refreshToken) {
+        this.$auth.refreshToken.set(refreshToken)
+      }
 
       // Update client id
       const clientId = getProp(data, this.options.clientId.property)


### PR DESCRIPTION
Refresh token should only be updated if defined in response of refresh endpoint.

> The response will be a new access token, and optionally a new refresh token, just like you received when exchanging the authorization code for an access token.
>If you do not get back a new refresh token, then it means your existing refresh token will continue to work when the new access token expires.

This fixes #592