### PR TITLE
feat(core): add support to function redirects

### DIFF
--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -315,6 +315,10 @@ export default class Auth {
       return
     }
 
+    if (typeof (to) === 'function') {
+      to = to(this.ctx)
+    }
+
     // Apply rewrites
     if (this.options.rewriteRedirects) {
       if (name === 'login' && isRelativeURL(from) && !isSameURL(to, from)) {

--- a/lib/module/plugin.js
+++ b/lib/module/plugin.js
@@ -8,7 +8,7 @@ import ExpiredAuthSessionError from './includes/ExpiredAuthSessionError'
 
 export default function (ctx, inject) {
   // Options
-  const options = <%= JSON.stringify(options.options) %>
+  const options = <%= serialize(options.options) %>
 
   // Create a new Auth instance
   const $auth = new Auth(ctx, options)


### PR DESCRIPTION
This PR add support to function redirects. You can conditionally change the redirect value for example.

```js
auth: {
  redirect: {
    home: (context) => {
      if(context.$auth.user.scope.includes('test')) {
        return '/test'
      }

      return '/home'
    }
  }
}
```