### PR TITLE
feat: cookie scheme and laravel sanctum

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -32,6 +32,7 @@ module.exports = {
           collapsable: false,
           children: [
             '/schemes/local',
+            '/schemes/cookie',
             '/schemes/refresh',
             '/schemes/oauth2'
           ]
@@ -44,7 +45,8 @@ module.exports = {
             '/providers/facebook',
             '/providers/github',
             '/providers/google',
-            '/providers/laravel-passport'
+            '/providers/laravel-passport',
+            '/providers/laravel-sanctum'
           ]
         }, {
           title: 'Recipes',

--- a/docs/providers/laravel-sanctum.md
+++ b/docs/providers/laravel-sanctum.md
@@ -1,0 +1,52 @@
+# Laravel Sanctum
+
+[Source Code](https://github.com/nuxt-community/auth-module/blob/master/lib/providers/laravel.sanctum.js)
+
+Laravel Sanctum provides a featherweight authentication system for SPAs (single page applications), mobile applications, and simple, token based APIs. Sanctum allows each user of your application to generate multiple API tokens for their account. These tokens may be granted abilities / scopes which specify which actions the tokens are allowed to perform. ([Read More](https://laravel.com/docs/7.x/sanctum))
+
+## Usage
+
+```js
+auth: {
+  strategies: {
+      'laravel.sanctum': {
+        url: '<laravel url>'
+      },
+  }
+}
+```
+
+**NOTE:** It is highly recommanded to use proxy to avoid CORS and same-site policy issues:
+
+```js
+{
+  axios: {
+    proxy: true
+  },
+  proxy: {
+    '/laravel': {
+      target: 'https://laravel-auth.nuxtjs.app',
+      pathRewrite: { '^/laravel': '/' }
+    }
+  },
+  auth: {
+    strategies: {
+      'laravel.sanctum': {
+        url: '<laravel url>'
+      }
+    }
+  }
+}
+```
+
+To login user:
+
+```js
+this.$auth.loginWith('laravel.sanctum', {
+  email: '',
+  password: ''
+})
+```
+
+💁 This provider is based on [cookie scheme](../schemes/cookie.md) and supports all scheme options.
+

--- a/docs/schemes/cookie.md
+++ b/docs/schemes/cookie.md
@@ -1,0 +1,29 @@
+# Cookie
+
+[Source Code](https://github.com/nuxt-community/auth-module/blob/dev/lib/schemes/cookie.js)
+
+`cookie` is an extended version of [local scheme](./local.md), which instead of using a token, depends on cookie set by auth provider.
+
+## Options
+
+**NOTE:** All [local scheme](./local.md) options are also supported.
+
+```js
+auth: {
+  strategies: {
+    cookie: {
+      cookie: {
+        // (optional) If set we check this cookie exsistence for loggedIn check
+        name: 'XSRF-TOKEN',
+      }
+    },
+    endpoints: {
+      // (optional) If set, we send a get request to this endpoint before login
+      xsrf: {
+        url: ''
+      }
+    }
+  }
+}
+```
+

--- a/docs/schemes/local.md
+++ b/docs/schemes/local.md
@@ -2,7 +2,9 @@
 
 [Source Code](https://github.com/nuxt-community/auth-module/blob/master/lib/schemes/local.js)
 
-`local` is the default, general purpose authentication scheme, supporting `Cookie` and `JWT` login flows.
+`local` is the default, credentials/token based scheme for flows like `JWT`.
+
+**Note:** You can use [cookie scheme](./cookie.md) which is based on local but modified for cookie based APIs.
 
 By default `local` scheme is enabled and preconfigured. You can set `strategies.local` to `false` to disable it.
 

--- a/examples/demo/nuxt.config.js
+++ b/examples/demo/nuxt.config.js
@@ -76,7 +76,7 @@ module.exports = {
         clientId: 'FAJNuxjMTicff6ciDKLiZ4t0D'
       },
       'laravel.sanctum': {
-        laravelBaseURL: '/laravel'
+        url: '/laravel'
       },
       oauth2mock: {
         _scheme: 'oauth2',

--- a/examples/demo/nuxt.config.js
+++ b/examples/demo/nuxt.config.js
@@ -16,7 +16,11 @@ module.exports = {
     proxy: true
   },
   proxy: {
-    '/api': 'http://localhost:3000'
+    '/api': 'http://localhost:3000',
+    '/laravel': {
+      target: 'https://laravel-auth.nuxtjs.app',
+      pathRewrite: { '^/laravel': '/' }
+    }
   },
   auth: {
     redirect: {
@@ -70,6 +74,9 @@ module.exports = {
       },
       twitter: {
         clientId: 'FAJNuxjMTicff6ciDKLiZ4t0D'
+      },
+      'laravel.sanctum': {
+        laravelBaseURL: '/laravel'
       },
       oauth2mock: {
         _scheme: 'oauth2',

--- a/examples/demo/pages/login.vue
+++ b/examples/demo/pages/login.vue
@@ -1,10 +1,11 @@
 <template>
   <div>
     <h2 class="text-center">Login</h2>
-    <hr>
-    <b-alert v-if="error" show variant="danger">{{ error + '' }}</b-alert>
+    <hr />
+    <b-alert v-if="errorMessage" show variant="danger">{{ errorMessage }}</b-alert>
     <b-alert show v-if="$auth.$state.redirect">
-      You have to login before accessing to <strong>{{ $auth.$state.redirect }}</strong>
+      You have to login before accessing to
+      <strong>{{ $auth.$state.redirect }}</strong>
     </b-alert>
     <b-row align-h="center" class="pt-4">
       <b-col md="4">
@@ -19,23 +20,43 @@
               <b-input type="password" v-model="password" placeholder="123" />
             </b-form-group>
 
+            <div class="text-center">
+              <b-btn @click="login" variant="primary" block>Login</b-btn>
+              <b-btn @click="localRefresh" variant="secondary" block>Login with Refresh</b-btn>
+            </div>
+          </form>
+        </b-card>
+      </b-col>
+      <b-col md="1" align-self="center">
         <div class="text-center">
-          <b-btn @click="login" variant="primary" block>Login</b-btn>
-          <b-btn @click="localRefresh" variant="primary" block>Login with Refresh</b-btn>
+          <b-badge pill>OR</b-badge>
         </div>
-        </form>
-      </b-card>
-    </b-col>
-    <b-col md="1" align-self="center">
-      <div class="text-center"><b-badge pill>OR</b-badge></div>
-    </b-col>
-    <b-col md="4" class="text-center">
+      </b-col>
+      <b-col md="4" class="text-center">
         <b-card title="Social Login" bg-variant="light">
           <div v-for="s in strategies" :key="s.key" class="mb-2">
-            <b-btn @click="$auth.loginWith(s.key)" block :style="{background: s.color}" class="login-button">Login with {{ s.name }}</b-btn>
+            <b-btn
+              @click="$auth.loginWith(s.key)"
+              block
+              :style="{background: s.color}"
+              class="login-button"
+            >Login with {{ s.name }}</b-btn>
           </div>
           <div class="mb-2">
-            <b-btn @click="$auth.loginWith('oauth2mock')" block :style="{background: 'purple'}" class="login-button">Login with oauth2</b-btn>
+            <b-btn
+              @click="$auth.loginWith('oauth2mock')"
+              block
+              :style="{background: 'purple'}"
+              class="login-button"
+            >Login with oauth2</b-btn>
+          </div>
+          <div class="mb-2">
+            <b-btn
+              @click="loginSanctum"
+              block
+              :style="{background: '#ff2d20'}"
+              class="login-button"
+            >Login with Laravel Sanctum (Test User)</b-btn>
           </div>
         </b-card>
       </b-col>
@@ -46,69 +67,101 @@
 <style scoped>
 .login-button {
   border: 0;
-};
+}
 </style>
 
 <script>
-import busyOverlay from '~/components/busy-overlay'
+import busyOverlay from "~/components/busy-overlay";
 
 export default {
-  middleware: ['auth'],
+  middleware: ["auth"],
   components: { busyOverlay },
   data() {
     return {
-      username: '',
-      password: '123',
+      username: "",
+      password: "123",
       error: null
-    }
+    };
   },
   computed: {
-    strategies: () => ([
-      { key: 'auth0', name: 'Auth0', color: '#ec5425' },
-      { key: 'google', name: 'Google', color: '#4284f4' },
-      { key: 'facebook', name: 'Facebook', color: '#3c65c4' },
-      { key: 'github', name: 'GitHub', color: '#202326' }
-    ]),
+    strategies: () => [
+      { key: "auth0", name: "Auth0", color: "#ec5425" },
+      { key: "google", name: "Google", color: "#4284f4" },
+      { key: "facebook", name: "Facebook", color: "#3c65c4" },
+      { key: "github", name: "GitHub", color: "#202326" }
+    ],
     redirect() {
       return (
         this.$route.query.redirect &&
         decodeURIComponent(this.$route.query.redirect)
-      )
+      );
     },
     isCallback() {
-      return Boolean(this.$route.query.callback)
+      return Boolean(this.$route.query.callback);
+    },
+    errorMessage() {
+      const { error } = this;
+      if (!error || typeof error === "string") {
+        return error;
+      }
+      let msg = "";
+      if (error.message) {
+        msg += error.message;
+      }
+      if (error.errors) {
+        msg += `(${JSON.stringify(error.errors)
+          .replace(/[{}"\[\]]/g, "")
+          .replace(/:/g, ": ")
+          .replace(/,/g, " ")})`;
+      }
+      return msg;
     }
   },
   methods: {
     async login() {
-      this.error = null
+      this.error = null;
 
       return this.$auth
-        .loginWith('local', {
+        .loginWith("local", {
           data: {
             username: this.username,
             password: this.password
           }
         })
         .catch(e => {
-          this.error = e.response.data + ''
-        })
+          this.error = e.response.data;
+        });
     },
 
     async localRefresh() {
-      this.error = null
+      this.error = null;
 
       return this.$auth
-        .loginWith('localRefresh', {
+        .loginWith("localRefresh", {
           data: {
             username: this.username,
             password: this.password
           }
         })
         .catch(e => {
-          this.error = e.response.data + ''
+          this.error = e.response.data;
+        });
+    },
+
+    async loginSanctum() {
+      this.error = null;
+
+      return this.$auth
+        .loginWith("laravel.sanctum", {
+          data: {
+            email: "test@test.com",
+            password: "12345678"
+          }
         })
+        .catch(e => {
+          this.error = e.response ? e.response.data : e.toString();
+        });
     }
   }
-}
+};
 </script>

--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -213,6 +213,17 @@ export default class Auth {
     return this.$state.loggedIn
   }
 
+  check () {
+    let loggedIn = Boolean(this.$state.user)
+
+    if (loggedIn && typeof this.strategy.check === 'function') {
+      loggedIn = this.strategy.check()
+    }
+
+    this.$storage.setState('loggedIn', loggedIn)
+    return loggedIn
+  }
+
   fetchUserOnce () {
     if (!this.$state.user) {
       return this.fetchUser(...arguments)
@@ -222,7 +233,7 @@ export default class Auth {
 
   setUser (user) {
     this.$storage.setState('user', user)
-    this.$storage.setState('loggedIn', Boolean(user))
+    this.check()
   }
 
   // ---------------------------------------------------------------

--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -258,10 +258,6 @@ export default class Auth {
 
     return this.ctx.app.$axios
       .request(_endpoint)
-      .then(response => ({
-        response,
-        data: response.data
-      }))
       .catch(error => {
         // Call all error handlers
         this.callOnError(error, { method: 'request' })

--- a/lib/core/storage.js
+++ b/lib/core/storage.js
@@ -213,7 +213,8 @@ export default class Storage {
       return
     }
 
-    const _key = this.options.cookie.prefix + key
+    const _prefix = options.prefix !== undefined ? options.prefix : this.options.cookie.prefix
+    const _key = _prefix + key
     const _options = Object.assign({}, this.options.cookie.options, options)
     const _value = encodeValue(value)
 

--- a/lib/core/utilities.js
+++ b/lib/core/utilities.js
@@ -111,6 +111,14 @@ export function getProp (holder, propName) {
   return result
 }
 
+export function getResponseProp (response, prop) {
+  if (prop[0] === '.') {
+    return getProp(response, prop.substring(1))
+  } else {
+    return getProp(response.data, prop)
+  }
+}
+
 // Ie "Bearer " + token
 export function addTokenPrefix (token, tokenType) {
   if (!token || !tokenType || token.startsWith(tokenType)) {

--- a/lib/providers/laravel.sanctum.js
+++ b/lib/providers/laravel.sanctum.js
@@ -19,6 +19,9 @@ module.exports = function laravelSanctum (strategy) {
   assignDefaults(strategy, {
     _scheme: 'cookie',
     _name: 'laravel.sanctum',
+    cookie: {
+      name: 'XSRF-TOKEN'
+    },
     endpoints: {
       csrf: {
         ...endpointDefaults,

--- a/lib/providers/laravel.sanctum.js
+++ b/lib/providers/laravel.sanctum.js
@@ -1,10 +1,10 @@
 const { assignDefaults } = require('./_utils')
 
 module.exports = function laravelSanctum (strategy) {
-  const { laravelBaseURL } = strategy
+  const { url } = strategy
 
-  if (!laravelBaseURL) {
-    throw new Error('laravelBaseURL is required!')
+  if (!url) {
+    throw new Error('url is required is laravel sanctum!')
   }
 
   const endpointDefaults = {
@@ -25,19 +25,19 @@ module.exports = function laravelSanctum (strategy) {
     endpoints: {
       csrf: {
         ...endpointDefaults,
-        url: laravelBaseURL + '/sanctum/csrf-cookie'
+        url: url + '/sanctum/csrf-cookie'
       },
       login: {
         ...endpointDefaults,
-        url: laravelBaseURL + '/login'
+        url: url + '/login'
       },
       logout: {
         ...endpointDefaults,
-        url: laravelBaseURL + '/logout'
+        url: url + '/logout'
       },
       user: {
         ...endpointDefaults,
-        url: laravelBaseURL + '/api/user'
+        url: url + '/api/user'
       }
     },
     user: {

--- a/lib/providers/laravel.sanctum.js
+++ b/lib/providers/laravel.sanctum.js
@@ -1,0 +1,44 @@
+const { assignDefaults } = require('./_utils')
+
+module.exports = function laravelSanctum (strategy) {
+  const { laravelBaseURL } = strategy
+
+  if (!laravelBaseURL) {
+    throw new Error('laravelBaseURL is required!')
+  }
+
+  const endpointDefaults = {
+    withCredentials: true,
+    headers: {
+      'X-Requested-With': 'XMLHttpRequest',
+      'Content-Type': 'application/json',
+      Accept: 'application/json'
+    }
+  }
+
+  assignDefaults(strategy, {
+    _scheme: 'cookie',
+    _name: 'laravel.sanctum',
+    endpoints: {
+      csrf: {
+        ...endpointDefaults,
+        url: laravelBaseURL + '/sanctum/csrf-cookie'
+      },
+      login: {
+        ...endpointDefaults,
+        url: laravelBaseURL + '/login'
+      },
+      logout: {
+        ...endpointDefaults,
+        url: laravelBaseURL + '/logout'
+      },
+      user: {
+        ...endpointDefaults,
+        url: laravelBaseURL + '/api/user'
+      }
+    },
+    user: {
+      property: false
+    }
+  })
+}

--- a/lib/schemes/cookie.js
+++ b/lib/schemes/cookie.js
@@ -7,6 +7,10 @@ export default class CookieScheme extends LocalScheme {
   }
 
   check () {
+    if (!super.check()) {
+      return false
+    }
+
     const cookies = this.$auth.$storage.getCookies()
     return Boolean(cookies[this.options.cookie.name])
   }

--- a/lib/schemes/cookie.js
+++ b/lib/schemes/cookie.js
@@ -39,7 +39,7 @@ export default class CookieScheme extends LocalScheme {
 
 const DEFAULTS = {
   cookie: {
-    name: 'XSRF-TOKEN'
+    name: null
   },
   token: {
     type: '',

--- a/lib/schemes/cookie.js
+++ b/lib/schemes/cookie.js
@@ -10,6 +10,15 @@ export default class CookieScheme extends LocalScheme {
     const cookies = this.$auth.$storage.getCookies()
     return Boolean(cookies[this.options.cookie.name])
   }
+
+  async login (endpoint) {
+    // Make CSRF request if required
+    if (this.options.endpoints.csrf) {
+      await this.$auth.request(this.options.endpoints.csrf)
+    }
+
+    return super.login(endpoint)
+  }
 }
 
 const DEFAULTS = {
@@ -18,5 +27,8 @@ const DEFAULTS = {
   },
   token: {
     required: false
+  },
+  endpoints: {
+    csrf: null
   }
 }

--- a/lib/schemes/cookie.js
+++ b/lib/schemes/cookie.js
@@ -12,7 +12,17 @@ export default class CookieScheme extends LocalScheme {
     }
 
     const cookies = this.$auth.$storage.getCookies()
-    return Boolean(cookies[this.options.cookie.name])
+
+    if (this.options.cookie.name) {
+      return Boolean(cookies[this.options.cookie.name])
+    }
+  }
+
+  async logout (endpoint) {
+    await super.logout(endpoint)
+    if (this.options.cookie.name) {
+      this.$auth.$storage.setCookie(this.options.cookie.name, null, { prefix: '' })
+    }
   }
 
   async login (endpoint) {

--- a/lib/schemes/cookie.js
+++ b/lib/schemes/cookie.js
@@ -1,0 +1,22 @@
+import defu from 'defu'
+import LocalScheme from './local'
+
+export default class CookieScheme extends LocalScheme {
+  constructor (auth, options) {
+    super(auth, defu(options, DEFAULTS))
+  }
+
+  check () {
+    const cookies = this.$auth.$storage.getCookies()
+    return Boolean(cookies[this.options.cookie.name])
+  }
+}
+
+const DEFAULTS = {
+  cookie: {
+    name: 'XSRF-TOKEN'
+  },
+  token: {
+    required: false
+  }
+}

--- a/lib/schemes/cookie.js
+++ b/lib/schemes/cookie.js
@@ -6,23 +6,28 @@ export default class CookieScheme extends LocalScheme {
     super(auth, defu(options, DEFAULTS))
   }
 
+  _getCookie () {
+    if (!this.options.cookie.name) {
+      return
+    }
+    const cookies = this.$auth.$storage.getCookies()
+    return cookies[this.options.cookie.name]
+  }
+
+  _getToken (response) {
+    return this._getCookie() || response.status
+  }
+
   check () {
     if (!super.check()) {
       return false
     }
 
-    const cookies = this.$auth.$storage.getCookies()
-
     if (this.options.cookie.name) {
-      return Boolean(cookies[this.options.cookie.name])
+      return Boolean(this._getCookie())
     }
-  }
 
-  async logout (endpoint) {
-    await super.logout(endpoint)
-    if (this.options.cookie.name) {
-      this.$auth.$storage.setCookie(this.options.cookie.name, null, { prefix: '' })
-    }
+    return true
   }
 
   async login (endpoint) {
@@ -33,6 +38,14 @@ export default class CookieScheme extends LocalScheme {
 
     return super.login(endpoint)
   }
+
+  async logout (endpoint) {
+    await super.logout(endpoint)
+
+    if (this.options.cookie.name) {
+      this.$auth.$storage.setCookie(this.options.cookie.name, null, { prefix: '' })
+    }
+  }
 }
 
 const DEFAULTS = {
@@ -40,7 +53,7 @@ const DEFAULTS = {
     name: 'XSRF-TOKEN'
   },
   token: {
-    required: false
+    type: ''
   },
   endpoints: {
     csrf: null

--- a/lib/schemes/cookie.js
+++ b/lib/schemes/cookie.js
@@ -6,25 +6,14 @@ export default class CookieScheme extends LocalScheme {
     super(auth, defu(options, DEFAULTS))
   }
 
-  _getCookie () {
-    if (!this.options.cookie.name) {
-      return
-    }
-    const cookies = this.$auth.$storage.getCookies()
-    return cookies[this.options.cookie.name]
-  }
-
-  _getToken (response) {
-    return this._getCookie() || response.status
-  }
-
   check () {
     if (!super.check()) {
       return false
     }
 
     if (this.options.cookie.name) {
-      return Boolean(this._getCookie())
+      const cookies = this.$auth.$storage.getCookies()
+      return Boolean(cookies[this.options.cookie.name])
     }
 
     return true
@@ -53,7 +42,8 @@ const DEFAULTS = {
     name: 'XSRF-TOKEN'
   },
   token: {
-    type: ''
+    type: '',
+    property: '.status'
   },
   endpoints: {
     csrf: null

--- a/lib/schemes/cookie.js
+++ b/lib/schemes/cookie.js
@@ -22,7 +22,9 @@ export default class CookieScheme extends LocalScheme {
   async login (endpoint) {
     // Make CSRF request if required
     if (this.options.endpoints.csrf) {
-      await this.$auth.request(this.options.endpoints.csrf)
+      await this.$auth.request(this.options.endpoints.csrf, {
+        maxRedirects: 0
+      })
     }
 
     return super.login(endpoint)

--- a/lib/schemes/cookie.js
+++ b/lib/schemes/cookie.js
@@ -43,7 +43,8 @@ const DEFAULTS = {
   },
   token: {
     type: '',
-    property: '.status'
+    property: '.status',
+    global: false
   },
   endpoints: {
     csrf: null

--- a/lib/schemes/local.js
+++ b/lib/schemes/local.js
@@ -60,6 +60,14 @@ export default class LocalScheme {
     return this.$auth.fetchUserOnce()
   }
 
+  check () {
+    if (this.options.token.required && !this.$auth.token.get()) {
+      return false
+    }
+
+    return true
+  }
+
   async login (endpoint) {
     if (!this.options.endpoints.login) {
       return
@@ -101,7 +109,7 @@ export default class LocalScheme {
 
   async fetchUser (endpoint) {
     // Token is required but not available
-    if (this.options.token.required && !this.$auth.token.get()) {
+    if (!this.check()) {
       return
     }
 

--- a/lib/schemes/local.js
+++ b/lib/schemes/local.js
@@ -68,11 +68,6 @@ export default class LocalScheme {
     // Ditch any leftover local tokens before attempting to log in
     await this.$auth.reset()
 
-    // Make CSRF request if required
-    if (this.options.endpoints.csrf) {
-      await this.$auth.request(this.options.endpoints.csrf)
-    }
-
     // Make login request
     const { response, data } = await this.$auth.request(
       endpoint,

--- a/lib/schemes/local.js
+++ b/lib/schemes/local.js
@@ -1,5 +1,5 @@
 import defu from 'defu'
-import { getProp } from '../utilities'
+import { getProp, getResponseProp } from '../utilities'
 import RequestHandler from '../requestHandler'
 
 export default class LocalScheme {
@@ -29,10 +29,6 @@ export default class LocalScheme {
     const _key = this.options.clientId.prefix + this.name
 
     return this.$auth.$storage.syncUniversal(_key)
-  }
-
-  _getToken (response) {
-    return getProp(response.data, this.options.token.property)
   }
 
   mounted () {
@@ -77,20 +73,20 @@ export default class LocalScheme {
     await this.$auth.reset()
 
     // Make login request
-    const { response, data } = await this.$auth.request(
+    const response = await this.$auth.request(
       endpoint,
       this.options.endpoints.login
     )
 
     // Update Token
     if (this.options.token.required) {
-      const token = this._getToken(response)
+      const token = getResponseProp(response, this.options.token.property)
       this.$auth.token.set(token)
     }
 
     // Update clientId
     if (this.options.clientId) {
-      this._setClientId(getProp(data, this.options.clientId.property))
+      this._setClientId(getResponseProp(response, this.options.clientId.property))
     }
 
     // Fetch user
@@ -121,13 +117,13 @@ export default class LocalScheme {
     }
 
     // Try to fetch user and then set
-    const { data } = await this.$auth.requestWith(
+    const response = await this.$auth.requestWith(
       this.name,
       endpoint,
       this.options.endpoints.user
     )
 
-    this.$auth.setUser(getProp(data, this.options.user.property))
+    this.$auth.setUser(getResponseProp(response, this.options.user.property))
   }
 
   async logout (endpoint = {}) {

--- a/lib/schemes/local.js
+++ b/lib/schemes/local.js
@@ -68,6 +68,11 @@ export default class LocalScheme {
     // Ditch any leftover local tokens before attempting to log in
     await this.$auth.reset()
 
+    // Make CSRF request if required
+    if (this.options.endpoints.csrf) {
+      await this.$auth.request(this.options.endpoints.csrf)
+    }
+
     // Make login request
     const { response, data } = await this.$auth.request(
       endpoint,

--- a/lib/schemes/local.js
+++ b/lib/schemes/local.js
@@ -13,10 +13,6 @@ export default class LocalScheme {
     this.requestHandler = new RequestHandler(this.$auth)
   }
 
-  // ---------------------------------------------------------------
-  // Client ID helpers
-  // ---------------------------------------------------------------
-
   _getClientId () {
     const _key = this.options.clientId.prefix + this.name
 
@@ -33,6 +29,10 @@ export default class LocalScheme {
     const _key = this.options.clientId.prefix + this.name
 
     return this.$auth.$storage.syncUniversal(_key)
+  }
+
+  _getToken (response) {
+    return getProp(response.data, this.options.token.property)
   }
 
   mounted () {
@@ -84,7 +84,8 @@ export default class LocalScheme {
 
     // Update Token
     if (this.options.token.required) {
-      this.$auth.token.set(getProp(data, this.options.token.property))
+      const token = this._getToken(response)
+      this.$auth.token.set(token)
     }
 
     // Update clientId

--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -254,7 +254,7 @@ export default class Oauth2Scheme {
     // Delete current token from the request header before refreshing
     this.requestHandler.clearHeader()
 
-    const { data } = await this.$auth.request(this.name, {
+    const response = await this.$auth.request(this.name, {
       method: 'post',
       url: this.options.endpoints.token,
       data: encodeQuery({
@@ -264,8 +264,8 @@ export default class Oauth2Scheme {
       })
     }, false, true)
 
-    const newToken = data[this.options.token.property]
-    const newRefreshToken = data[this.options.refreshToken.property]
+    const newToken = response.data[this.options.token.property]
+    const newRefreshToken = response.data[this.options.refreshToken.property]
 
     // Update tokens
     this.$auth.token.set(newToken)

--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -254,7 +254,7 @@ export default class Oauth2Scheme {
     // Delete current token from the request header before refreshing
     this.requestHandler.clearHeader()
 
-    const { response, data } = await this.$auth.request(this.name, {
+    const { data } = await this.$auth.request(this.name, {
       method: 'post',
       url: this.options.endpoints.token,
       data: encodeQuery({

--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -92,6 +92,10 @@ export default class Oauth2Scheme {
     }
   }
 
+  check () {
+    return !!this.$auth.token.get()
+  }
+
   async reset () {
     this.$auth.setUser(false)
     this.$auth.token.reset()
@@ -147,7 +151,7 @@ export default class Oauth2Scheme {
   }
 
   async fetchUser () {
-    if (!this.$auth.token.get()) {
+    if (!this.check()) {
       return
     }
 

--- a/lib/schemes/refresh.js
+++ b/lib/schemes/refresh.js
@@ -1,6 +1,6 @@
 import defu from 'defu'
 import LocalScheme from './local'
-import { getProp } from '../utilities'
+import { getResponseProp } from '../utilities'
 import RefreshController from '../refreshController'
 import ExpiredAuthSessionError from '../includes/ExpiredAuthSessionError'
 
@@ -64,18 +64,18 @@ export default class RefreshScheme extends LocalScheme {
     await this.$auth.reset()
 
     // Make login request
-    const { response, data } = await this.$auth.request(
+    const response = await this.$auth.request(
       endpoint,
       this.options.endpoints.login
     )
 
     // Update tokens
-    this.$auth.token.set(getProp(data, this.options.token.property))
-    this.$auth.refreshToken.set(getProp(data, this.options.refreshToken.property))
+    this.$auth.token.set(getResponseProp(response, this.options.token.property))
+    this.$auth.refreshToken.set(getResponseProp(response, this.options.refreshToken.property))
 
     // Update client id
     if (this.options.clientId) {
-      this._setClientId(getProp(data, this.options.clientId.property))
+      this._setClientId(getResponseProp(response, this.options.clientId.property))
     }
 
     // Initialize scheduled refresh if `autoRefresh` is enabled
@@ -104,7 +104,7 @@ export default class RefreshScheme extends LocalScheme {
     let requestFailed = false
 
     // Try to fetch user and then set
-    const { data } = await this.$auth.requestWith(
+    const response = await this.$auth.requestWith(
       this.name,
       endpoint,
       this.options.endpoints.user
@@ -115,7 +115,7 @@ export default class RefreshScheme extends LocalScheme {
 
     // If the request has not failed, set user data
     if (!requestFailed) {
-      this.$auth.setUser(getProp(data, this.options.user.property))
+      this.$auth.setUser(getResponseProp(response, this.options.user.property))
     }
   }
 
@@ -157,9 +157,9 @@ export default class RefreshScheme extends LocalScheme {
       endpoint,
       this.options.endpoints.refresh,
       true
-    ).then(({ response, data }) => {
-      const token = getProp(data, this.options.token.property)
-      const refreshToken = getProp(data, this.options.refreshToken.property)
+    ).then((response) => {
+      const token = getResponseProp(response, this.options.token.property)
+      const refreshToken = getResponseProp(response, this.options.refreshToken.property)
 
       // Update tokens
       this.$auth.token.set(token)
@@ -169,7 +169,7 @@ export default class RefreshScheme extends LocalScheme {
       }
 
       // Update client id
-      const clientId = getProp(data, this.options.clientId.property)
+      const clientId = getResponseProp(response, this.options.clientId.property)
       if (this.options.clientId && clientId) {
         this._setClientId(clientId)
       }

--- a/lib/schemes/refresh.js
+++ b/lib/schemes/refresh.js
@@ -48,6 +48,14 @@ export default class RefreshScheme extends LocalScheme {
     })
   }
 
+  check () {
+    if (!this.$auth.token.get() || !this.$auth.refreshToken.get()) {
+      return false
+    }
+
+    return true
+  }
+
   async login (endpoint) {
     // Login endpoint is disabled
     if (!this.options.endpoints.login) return
@@ -85,7 +93,7 @@ export default class RefreshScheme extends LocalScheme {
 
   async fetchUser (endpoint) {
     // Token is required but not available
-    if (!this.$auth.token.get()) return
+    if (!this.check()) return
 
     // User endpoint is disabled.
     if (!this.options.endpoints.user) {
@@ -115,12 +123,8 @@ export default class RefreshScheme extends LocalScheme {
     // Refresh endpoint is disabled
     if (!this.options.endpoints.refresh) return
 
-    // Get token and refresh token
-    const token = this.$auth.token.get()
-    const refreshToken = this.$auth.refreshToken.get()
-
     // Token and refresh token are required but not available
-    if (!token || !refreshToken) return
+    if (!this.check()) return
 
     // Get refresh token status
     const refreshTokenStatus = this.$auth.refreshToken.status()
@@ -134,7 +138,7 @@ export default class RefreshScheme extends LocalScheme {
 
     const endpoint = {
       data: {
-        [this.options.refreshToken.data]: refreshToken
+        [this.options.refreshToken.data]: this.$auth.refreshToken.get()
       }
     }
 


### PR DESCRIPTION
- feat(auth): support strategy.check
  - This new hook allows strategies to validate loggedIn status based on their logic in addition to basic user boolean check
- New cookie scheme
  - based on local
  - token disabled by default
  - csrf endpoint support
  - `XSRF-TOKEN` cookie checker for loggedIn 
- Added Laravel [Sanctum](https://laravel.com/docs/7.x/sanctum) provider
  - based on cookie scheme with decent defaults
  - Added to the demo
- added new `getResponseProperty` util to be able to read from headers or status
- request and requestWith utils directly return response

## Todo

- [ ] Sanctum provider docs
- [ ] Cookie scheme docs


Credits: #557 #556 to @JoaoPedroAS51 :green_heart: 

