### PR TITLE
fix(core): throw error if trying to set an undefined strategy

### DIFF
--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -107,6 +107,10 @@ export default class Auth {
       return Promise.resolve()
     }
 
+    if (!this.strategies[name]) {
+      throw new Error(`Strategy ${name} is not defined!`)
+    }
+
     // Set strategy
     this.$storage.setUniversal('strategy', name)
 


### PR DESCRIPTION
This error will be thrown if you try to set an undefined strategy. For example when using `this.$auth.loginWith('my-undefined-strategy')`

There are two cases: 
- If your strategy wasn't added to auth config.
- If your strategy scheme wasn't found. 

The current error:
---
![bandicam 2020-04-19 14-37-59-851](https://user-images.githubusercontent.com/15177236/79695134-6365de80-824b-11ea-8097-4f593284f731.jpg)

With this fix:
---
![bandicam 2020-04-19 14-38-03-771](https://user-images.githubusercontent.com/15177236/79695136-64970b80-824b-11ea-85c2-9be97af34025.jpg)


