### PR TITLE
fix(cookie scheme): include parent scheme during build

### DIFF
--- a/lib/module/index.js
+++ b/lib/module/index.js
@@ -152,10 +152,11 @@ function processStrategies (options) {
       fileName: join('auth', 'schemes', schemeName)
     })
 
-    if (schemeName === 'refresh.js') {
+    // Ensure parent scheme is included in the build
+    if (['refresh.js', 'cookie.js'].includes(schemeName)) {
       this.addTemplate({
-        src: schemeSrc.replace('refresh.js', 'local.js'),
-        fileName: join('auth', 'schemes', schemeName.replace('refresh.js', 'local.js'))
+        src: schemeSrc.replace(schemeName, 'local.js'),
+        fileName: join('auth', 'schemes', schemeName.replace(schemeName, 'local.js'))
       })
     }
 


### PR DESCRIPTION
Fixes the following compile error:

```
This relative module was not found:
* ./local in ./.nuxt/auth/schemes/cookie.js
```