### PR TITLE
feat: add DocSearch as recommended by vuepress

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -2,6 +2,10 @@ module.exports = {
   title: 'Auth Module',
   description: 'Authentication module for Nuxt',
   themeConfig: {
+    algolia: {
+      apiKey: '40443e7f7f59ee3f7927b6b9176100a6',
+      indexName: 'nuxtjs_auth'
+    },
     repo: 'nuxt-community/auth-module',
     docsDir: 'docs',
     editLinks: true,


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Vuepress](https://vuepress.vuejs.org/theme/default-theme-config.html#algolia-search). We thought it is a shame you can not also used this search that you can [find on vuejs for example](https://vuejs.org/).

This PR will add DocSearch to the documentation website. It will allow a user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.