### PR TITLE
fix(module): throw error if scheme is not defined

### DIFF
--- a/src/module/resolve.ts
+++ b/src/module/resolve.ts
@@ -1,7 +1,9 @@
 /* eslint-disable import/namespace */
 import { existsSync } from 'fs'
+import consola from 'consola'
 import * as providers from '../providers'
 
+const logger = consola.withScope('nuxt:auth')
 const builtInSchemes = [
   'local',
   'cookie',
@@ -75,7 +77,7 @@ export function resolveScheme (nuxt, scheme) {
       return path
     }
   } catch (e) {
-    // Ignore
+    logger.fatal(`Scheme ${scheme} is not defined!`)
   }
 }
 

--- a/src/module/resolve.ts
+++ b/src/module/resolve.ts
@@ -77,7 +77,7 @@ export function resolveScheme (nuxt, scheme) {
       return path
     }
   } catch (e) {
-    logger.fatal(`Scheme ${scheme} is not defined!`)
+    logger.fatal(`Scheme ${scheme} wasn't found!`)
   }
 }
 


### PR DESCRIPTION
Throw an error if strategy scheme wasn't found.

Example code:
```js
myStrategy: {
  // Missing scheme: 'local'
  token: {
    property: 'token.accessToken'
  }
},
```

The current error:
---
![image](https://user-images.githubusercontent.com/15177236/80608745-9e1b0400-8a0d-11ea-9822-78355a551876.png)

With this fix:
---
![bandicam 2020-04-29 11-43-11-152](https://user-images.githubusercontent.com/15177236/80609556-9c9e0b80-8a0e-11ea-99dd-aa1612c7942e.jpg)
