### PR TITLE
fix(laravel sanctum): set `referer` header on mount

### DIFF
--- a/src/schemes/cookie.ts
+++ b/src/schemes/cookie.ts
@@ -1,4 +1,3 @@
-import requrl from 'requrl'
 import LocalScheme from './local'
 
 const DEFAULTS = {
@@ -18,17 +17,13 @@ const DEFAULTS = {
 }
 
 export default class CookieScheme extends LocalScheme {
-  public req
-
   constructor ($auth, options) {
     super($auth, options, DEFAULTS)
-
-    this.req = $auth.ctx.req
   }
 
   mounted () {
     if (process.server) {
-      this.$auth.ctx.$axios.setHeader('referer', requrl(this.req))
+      this.$auth.ctx.$axios.setHeader('referer', this.$auth.ctx.req)
     }
 
     return super.mounted()

--- a/src/schemes/cookie.ts
+++ b/src/schemes/cookie.ts
@@ -8,6 +8,7 @@ const DEFAULTS = {
   token: {
     type: '',
     property: '.status',
+    maxAge: false,
     global: false
   },
   endpoints: {

--- a/src/schemes/cookie.ts
+++ b/src/schemes/cookie.ts
@@ -1,3 +1,4 @@
+import requrl from 'requrl'
 import LocalScheme from './local'
 
 const DEFAULTS = {
@@ -17,8 +18,20 @@ const DEFAULTS = {
 }
 
 export default class CookieScheme extends LocalScheme {
+  public req
+
   constructor ($auth, options) {
     super($auth, options, DEFAULTS)
+
+    this.req = $auth.ctx.req
+  }
+
+  mounted () {
+    if (process.server) {
+      this.$auth.ctx.$axios.setHeader('referer', requrl(this.req))
+    }
+
+    return super.mounted()
   }
 
   check () {


### PR DESCRIPTION
Seems that Laravel Sanctum requires `referer` header in SSR request to authorize the request. This fix will set `referer` header on mount. 
This also set token `maxAge` to `false` as we are not using token.

Fixes #653 