### PR TITLE
fix(provider utils): return correct error response

### DIFF
--- a/demo/pages/login.vue
+++ b/demo/pages/login.vue
@@ -230,7 +230,7 @@ export default {
           }
         })
         .catch((e) => {
-          this.error = e.response ? e.response.data : e.toString()
+          this.error = e.response ? e.response.data.message : e.toString()
         })
     },
 

--- a/src/providers/_utils.ts
+++ b/src/providers/_utils.ts
@@ -75,7 +75,10 @@ export function addAuthorize (nuxt, strategy) {
           .then((response) => {
             res.end(JSON.stringify(response.data))
           })
-          .catch(error => next(error))
+          .catch((error) => {
+            res.statusCode = error.response.status
+            res.end(JSON.stringify(error.response.data))
+          })
       })
     }
   })

--- a/src/providers/_utils.ts
+++ b/src/providers/_utils.ts
@@ -147,7 +147,10 @@ export function initializePasswordGrantFlow (nuxt, strategy) {
           .then((response) => {
             res.end(JSON.stringify(response.data))
           })
-          .catch(error => next(error))
+          .catch((error) => {
+            res.statusCode = error.response.status
+            res.end(JSON.stringify(error.response.data))
+          })
       })
     }
   })


### PR DESCRIPTION
This PR fixes the error response of `addAuthorize` and `initializePasswordGrantFlow`.
It returns the data provided by the original response instead of returning NuxtServerError. That way we can access the error message of the response.


Fixes #659 