### PR TITLE
refactor(schemes): simplify schemes removing duplicates

### DIFF
--- a/src/schemes/local.ts
+++ b/src/schemes/local.ts
@@ -52,7 +52,7 @@ export default class LocalScheme extends BaseScheme<typeof DEFAULTS> {
     }
   }
 
-  async mounted () {
+  async _checkStatus () {
     if (this.options.token.required) {
       // Sync token
       this.$auth.token.sync()
@@ -65,6 +65,10 @@ export default class LocalScheme extends BaseScheme<typeof DEFAULTS> {
         await this.$auth.reset()
       }
     }
+  }
+
+  async mounted () {
+    await this._checkStatus()
 
     // Initialize request interceptor
     this.requestHandler.initializeRequestInterceptor()

--- a/src/schemes/local.ts
+++ b/src/schemes/local.ts
@@ -67,11 +67,11 @@ export default class LocalScheme extends BaseScheme<typeof DEFAULTS> {
     }
   }
 
-  async mounted () {
+  async mounted ({ refreshEndpoint = undefined } = {}) {
     await this._checkStatus()
 
     // Initialize request interceptor
-    this.requestHandler.initializeRequestInterceptor()
+    this.requestHandler.initializeRequestInterceptor(refreshEndpoint)
 
     // Fetch user once
     return this.$auth.fetchUserOnce()

--- a/src/schemes/local.ts
+++ b/src/schemes/local.ts
@@ -45,6 +45,13 @@ export default class LocalScheme extends BaseScheme<typeof DEFAULTS> {
     this.requestHandler = new RequestHandler(this.$auth)
   }
 
+  _updateTokens (response) {
+    if (this.options.token.required) {
+      const token = getResponseProp(response, this.options.token.property)
+      this.$auth.token.set(token)
+    }
+  }
+
   async mounted () {
     if (this.options.token.required) {
       // Sync token
@@ -98,13 +105,10 @@ export default class LocalScheme extends BaseScheme<typeof DEFAULTS> {
       this.options.endpoints.login
     )
 
-    // Update Token
-    if (this.options.token.required) {
-      const token = getResponseProp(response, this.options.token.property)
-      this.$auth.token.set(token)
-    }
+    // Update tokens
+    this._updateTokens(response)
 
-    // Fetch user
+    // Fetch user if `autoFetch` is enabled
     if (this.options.user.autoFetch) {
       await this.fetchUser()
     }

--- a/src/schemes/oauth2.ts
+++ b/src/schemes/oauth2.ts
@@ -1,6 +1,6 @@
 import { nanoid } from 'nanoid'
 import requrl from 'requrl'
-import { encodeQuery, parseQuery, normalizePath, getResponseProp, urlJoin } from '../utils'
+import { encodeQuery, parseQuery, normalizePath, getResponseProp, urlJoin, removeTokenPrefix } from '../utils'
 import RefreshController from '../inc/refresh-controller'
 import RequestHandler from '../inc/request-handler'
 import ExpiredAuthSessionError from '../inc/expired-auth-session-error'
@@ -254,7 +254,7 @@ export default class Oauth2Scheme extends BaseScheme<typeof DEFAULTS> {
       method: 'post',
       url: this.options.endpoints.token,
       data: encodeQuery({
-        refresh_token: refreshToken.replace(this.$auth.options.token.type + ' ', ''),
+        refresh_token: removeTokenPrefix(refreshToken, this.$auth.options.token.type),
         client_id: this.options.clientId,
         grant_type: 'refresh_token'
       })

--- a/src/schemes/refresh.ts
+++ b/src/schemes/refresh.ts
@@ -59,15 +59,8 @@ export default class RefreshScheme extends LocalScheme {
     }
   }
 
-  // TODO: Remove `mounted` method after unify `initializeRequestInterceptor` method of RefreshController with RequestHandler
-  async mounted () {
-    await this._checkStatus()
-
-    // Initialize request interceptor
-    this.requestHandler.initializeRequestInterceptor(this.options.endpoints.refresh.url)
-
-    // Fetch user once
-    return this.$auth.fetchUserOnce()
+  mounted () {
+    return super.mounted({ refreshEndpoint: this.options.endpoints.refresh.url })
   }
 
   check () {

--- a/src/schemes/refresh.ts
+++ b/src/schemes/refresh.ts
@@ -41,7 +41,7 @@ export default class RefreshScheme extends LocalScheme {
     }
   }
 
-  async mounted () {
+  async _checkStatus () {
     // Sync tokens
     this.$auth.token.sync()
     this.$auth.refreshToken.sync()
@@ -57,6 +57,11 @@ export default class RefreshScheme extends LocalScheme {
     } else if (this.options.autoLogout && tokenStatus.expired()) {
       await this.$auth.reset()
     }
+  }
+
+  // TODO: Remove `mounted` method after unify `initializeRequestInterceptor` method of RefreshController with RequestHandler
+  async mounted () {
+    await this._checkStatus()
 
     // Initialize request interceptor
     this.refreshController.initializeRequestInterceptor(this.options.endpoints.refresh.url)

--- a/src/schemes/refresh.ts
+++ b/src/schemes/refresh.ts
@@ -6,30 +6,10 @@ import LocalScheme from './local'
 const DEFAULTS = {
   name: 'refresh',
   endpoints: {
-    login: {
-      url: '/api/auth/login',
-      method: 'post'
-    },
     refresh: {
       url: '/api/auth/refresh',
       method: 'post'
-    },
-    logout: {
-      url: '/api/auth/logout',
-      method: 'post'
-    },
-    user: {
-      url: '/api/auth/user',
-      method: 'get'
     }
-  },
-  token: {
-    property: 'token',
-    type: 'Bearer',
-    name: 'Authorization',
-    maxAge: 1800,
-    global: true,
-    required: true
   },
   refreshToken: {
     property: 'refresh_token',
@@ -37,12 +17,6 @@ const DEFAULTS = {
     maxAge: 60 * 60 * 24 * 30,
     required: true
   },
-  user: {
-    property: 'user',
-    autoFetch: true
-  },
-  clientId: false,
-  grantType: false,
   autoLogout: false
 }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -135,6 +135,14 @@ export function addTokenPrefix (token, tokenType) {
   return tokenType + ' ' + token
 }
 
+export function removeTokenPrefix (token, tokenType) {
+  if (!token || !tokenType) {
+    return token
+  }
+
+  return token.replace(tokenType + ' ', '')
+}
+
 export function urlJoin (...args) {
   return args.join('/')
     .replace(/[/]+/g, '/')


### PR DESCRIPTION
- Add new private method `_updateTokens` that is used to update token and refresh token values. That way we can remove `login` method from refresh scheme as it becomes identical to local scheme method. 
- Add new private method `_checkStatus` that is used to check status of token and refresh token. It forces reset if refresh token has expired or if `autoLogout` is enabled and token has expired. That way we can remove `mounted` method from refresh scheme as it is identical to local scheme method.
- Remove `fetchUser` from refresh scheme as it is identical to local scheme method.