### PR TITLE
refactor(request handler, refresh controller): unify request interceptor

### DIFF
--- a/docs/api/refreshController.md
+++ b/docs/api/refreshController.md
@@ -24,18 +24,6 @@ export class SchemeName {
 }
 ```
 
-Then it will be available through the scheme
-
-```js
-mounted () {
-  ...
-
-  this.refreshController.initializeRequestInterceptor(refreshEnpoint)
-
-  ...
-}
-```
-
 ## methods
 
 ### `handleRefresh()`
@@ -47,19 +35,3 @@ Multiple requests will be queued until the first has completed token refresh.
 ::: warning IMPORTANT
 You **must** add `refreshTokens` method to your scheme in order to work.
 :::
-
-### `initializeScheduledRefresh()`
-
-Refreshes the token when time reaches 75% of the token expiration. It uses [refreshIn](tokens.md#refreshin) to get time intervals.
-
-::: warning IMPORTANT
-Call this function **once** from your mounted hook, **client side** only
-:::
-
-### `initializeRequestInterceptor(refreshEndpoint)`
-
-Watch requests for token expiration and refresh tokens if token has expired.
-
-### `reset()`
-
-Reset properties of **RefreshController**. Call it when logging out.

--- a/src/inc/refresh-controller.ts
+++ b/src/inc/refresh-controller.ts
@@ -30,8 +30,4 @@ export default class RefreshController {
 
     return this._doRefresh()
   }
-
-  reset () {
-    //
-  }
 }

--- a/src/schemes/oauth2.ts
+++ b/src/schemes/oauth2.ts
@@ -83,7 +83,7 @@ export default class Oauth2Scheme extends BaseScheme<typeof DEFAULTS> {
     }
 
     // Initialize request interceptor
-    this.refreshController.initializeRequestInterceptor(this.options.endpoints.token)
+    this.requestHandler.initializeRequestInterceptor(this.options.endpoints.token)
 
     // Handle callbacks on page load
     const redirected = await this._handleCallback()

--- a/src/schemes/oauth2.ts
+++ b/src/schemes/oauth2.ts
@@ -100,7 +100,6 @@ export default class Oauth2Scheme extends BaseScheme<typeof DEFAULTS> {
   async reset () {
     this.$auth.setUser(false)
     this.$auth.token.reset()
-    this.$auth.refreshToken.reset()
 
     return Promise.resolve()
   }

--- a/src/schemes/refresh.ts
+++ b/src/schemes/refresh.ts
@@ -221,7 +221,6 @@ export default class RefreshScheme extends LocalScheme {
     this.$auth.setUser(false)
     this.$auth.token.reset()
     this.$auth.refreshToken.reset()
-    this.refreshController.reset()
 
     return Promise.resolve()
   }

--- a/src/schemes/refresh.ts
+++ b/src/schemes/refresh.ts
@@ -74,7 +74,7 @@ export default class RefreshScheme extends LocalScheme {
     }
 
     // Initialize request interceptor
-    this.refreshController.initializeRequestInterceptor(this.options.endpoints.refresh.url)
+    this.requestHandler.initializeRequestInterceptor(this.options.endpoints.refresh.url)
 
     // Fetch user once
     return this.$auth.fetchUserOnce()


### PR DESCRIPTION
Unify method `initializeRequestInterceptor` of RefreshController with RequestHandler. This make it clear and easier to use. RefreshController class only handles refresh now.