### PR TITLE
fix: catch refresh request error

### DIFF
--- a/src/inc/refresh-controller.ts
+++ b/src/inc/refresh-controller.ts
@@ -9,10 +9,13 @@ export default class RefreshController {
   }
 
   _doRefresh () {
-    this._refreshPromise = new Promise((resolve) => {
+    this._refreshPromise = new Promise((resolve, reject) => {
       this.scheme.refreshTokens().then((response) => {
         this._refreshPromise = null
         resolve(response)
+      }).catch((error) => {
+        this._refreshPromise = null
+        reject(error)
       })
     })
 

--- a/src/inc/request-handler.ts
+++ b/src/inc/request-handler.ts
@@ -70,7 +70,11 @@ export default class RequestHandler {
       }
 
       // Refresh token before sending current request
-      await this.$auth.refreshTokens()
+      await this.$auth.refreshTokens().catch(async () => {
+        // Tokens couldn't be refreshed. Force reset.
+        await this.$auth.reset()
+        throw new ExpiredAuthSessionError()
+      })
 
       // Fetch updated token and add to current request
       return this._getUpdatedRequestConfig(config)

--- a/src/schemes/oauth2.ts
+++ b/src/schemes/oauth2.ts
@@ -341,6 +341,9 @@ export default class Oauth2Scheme extends BaseScheme<typeof DEFAULTS> {
         client_id: this.options.clientId,
         grant_type: 'refresh_token'
       })
+    }).catch((error) => {
+      this.$auth.callOnError(error, { method: 'refreshToken' })
+      return Promise.reject(error)
     })
 
     this._updateTokens(response)

--- a/src/schemes/refresh.ts
+++ b/src/schemes/refresh.ts
@@ -128,6 +128,7 @@ export default class RefreshScheme extends LocalScheme {
       return response
     }).catch((error) => {
       this.$auth.callOnError(error, { method: 'refreshToken' })
+      return Promise.reject(error)
     })
   }
 


### PR DESCRIPTION
Fix an issue that was preventing other requests if refresh request failed.
Also add support to catch errors from `$auth.refreshTokens()`