### PR TITLE
docs: add missing provider key to laravelSanctum example

### DIFF
--- a/docs/providers/laravel-sanctum.md
+++ b/docs/providers/laravel-sanctum.md
@@ -33,6 +33,7 @@ auth: {
   auth: {
     strategies: {
       'laravelSanctum': {
+        provider: 'laravel/sanctum',
         url: '<laravel url>'
       }
     }


### PR DESCRIPTION
Missing provider in second example causes a scheme-not-found error when trying to start nuxt.
![image](https://user-images.githubusercontent.com/19362349/81509101-9c541900-9308-11ea-88fc-2d313aac709c.png)

```js
{
  axios: {
    proxy: true
  },
  proxy: {
    '/laravel': {
      target: 'https://laravel-auth.nuxtjs.app',
      pathRewrite: { '^/laravel': '/' }
    }
  },
  auth: {
    strategies: {
      'laravelSanctum': {
        //provider: 'laravel/sanctum', <-- This was missing
        url: '<laravel url>'
      }
    }
  }
}
```