### PR TITLE
fix(laravel passport): ignore axios `baseURL` for password grant flow

### DIFF
--- a/src/providers/laravel/passport.ts
+++ b/src/providers/laravel/passport.ts
@@ -32,8 +32,12 @@ export default function laravelPassport (nuxt, strategy) {
       scheme: 'refresh',
       endpoints: {
         token: url + '/oauth/token',
-        login: {},
-        refresh: {},
+        login: {
+          baseURL: process.server ? undefined : false
+        },
+        refresh: {
+          baseURL: process.server ? undefined : false
+        },
         logout: false,
         user: {
           url: url + '/api/auth/user'


### PR DESCRIPTION
Axios `baseURL` should be ignored for password grant flow as `login` and `refresh` endpoints are `serverMiddleware`.

Fixes #682 