### PR TITLE
feat: improve token handling and validation

### DIFF
--- a/demo/pages/secure.vue
+++ b/demo/pages/secure.vue
@@ -15,14 +15,14 @@
           Test: <b-badge>{{ $auth.hasScope('test') }}</b-badge>
           Admin: <b-badge>{{ $auth.hasScope('admin') }}</b-badge>
         </b-card>
-        <b-card title="token" class="mb-2">
+        <b-card v-if="$auth.strategy.token" title="token" class="mb-2">
           <div style="white-space: nowrap; overflow: auto">
-            {{ $auth.token.get() || '-' }}
+            {{ $auth.strategy.token.get() || '-' }}
           </div>
         </b-card>
-        <b-card title="refresh token">
+        <b-card v-if="$auth.strategy.refreshToken" title="refresh token">
           <div style="white-space: nowrap; overflow: auto">
-            {{ $auth.refreshToken.get() || '-' }}
+            {{ $auth.strategy.refreshToken.get() || '-' }}
           </div>
         </b-card>
       </b-col>

--- a/docs/providers/laravel-sanctum.md
+++ b/docs/providers/laravel-sanctum.md
@@ -33,6 +33,7 @@ auth: {
   auth: {
     strategies: {
       'laravelSanctum': {
+        provider: 'laravel/sanctum',
         url: '<laravel url>'
       }
     }

--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -216,14 +216,11 @@ export default class Auth {
   }
 
   check (...args) {
-    let loggedIn = Boolean(this.$state.user)
-
-    if (loggedIn && typeof this.strategy.check === 'function') {
-      loggedIn = this.strategy.check(...args)
+    if (!this.strategy.check) {
+      return { valid: true }
     }
 
-    this.$storage.setState('loggedIn', loggedIn)
-    return loggedIn
+    return this.strategy.check(...args)
   }
 
   fetchUserOnce (...args) {
@@ -235,7 +232,16 @@ export default class Auth {
 
   setUser (user) {
     this.$storage.setState('user', user)
-    this.check()
+
+    let check = { valid: Boolean(user) }
+
+    // If user is defined, perform scheme checks.
+    if (check.valid) {
+      check = this.check()
+    }
+
+    // Update `loggedIn` state
+    this.$storage.setState('loggedIn', check.valid)
   }
 
   // ---------------------------------------------------------------

--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -246,7 +246,7 @@ export default class Auth {
     return this.$storage.getState('busy')
   }
 
-  request (endpoint: AxiosRequestConfig, defaults = {}): Promise<AxiosResponse> {
+  request (endpoint: AxiosRequestConfig, defaults: AxiosRequestConfig = {}): Promise<AxiosResponse> {
     const _endpoint =
       typeof defaults === 'object'
         ? Object.assign({}, defaults, endpoint)

--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -1,6 +1,5 @@
-import type { AxiosRequestConfig, AxiosResponse } from 'axios'
 import { routeOption, isRelativeURL, isSet, isSameURL, getProp } from '../utils'
-import type { AuthOptions } from '../'
+import type { AuthOptions, HTTPRequest, HTTPResponse } from '../'
 import Storage from './storage'
 
 export default class Auth {
@@ -252,7 +251,7 @@ export default class Auth {
     return this.$storage.getState('busy')
   }
 
-  request (endpoint: AxiosRequestConfig, defaults: AxiosRequestConfig = {}): Promise<AxiosResponse> {
+  request (endpoint: HTTPRequest, defaults: HTTPRequest = {}): Promise<HTTPResponse> {
     const _endpoint =
       typeof defaults === 'object'
         ? Object.assign({}, defaults, endpoint)
@@ -275,7 +274,7 @@ export default class Auth {
       })
   }
 
-  requestWith (strategy: string, endpoint: AxiosRequestConfig, defaults?: AxiosRequestConfig): Promise<AxiosResponse> {
+  requestWith (strategy: string, endpoint: HTTPRequest, defaults?: HTTPRequest): Promise<HTTPResponse> {
     const token = this.strategy.token.get()
 
     const _endpoint = Object.assign({}, defaults, endpoint)

--- a/src/core/middleware.ts
+++ b/src/core/middleware.ts
@@ -29,7 +29,7 @@ export default async function authMiddleware (ctx) {
     await ctx.$auth.check(true, (isRefreshable) => {
       // Refresh token is available. Attempt refresh.
       if (isRefreshable) {
-        return this.$auth.refreshTokens()
+        return ctx.$auth.refreshTokens()
           .then(() => true)
           .catch(() => false)
       }

--- a/src/inc/refresh-token.ts
+++ b/src/inc/refresh-token.ts
@@ -1,37 +1,40 @@
 import jwtDecode, { InvalidTokenError } from 'jwt-decode'
 import { addTokenPrefix } from '../utils'
-import type { Auth } from '../'
+import type { Scheme } from '../'
+import Storage from '../core/storage'
 import TokenStatus from './token-status'
 
 export default class RefreshToken {
-  public $auth: Auth
+  public scheme: Scheme
+  public $storage: Storage
 
-  constructor (auth: Auth) {
-    this.$auth = auth
+  constructor (scheme: Scheme, storage: Storage) {
+    this.scheme = scheme
+    this.$storage = storage
   }
 
   _getExpiration () {
-    const _key = this.$auth.options.refreshTokenExpiration.prefix + this.$auth.strategy.name
+    const _key = this.scheme.options.refreshToken.expirationPrefix + this.scheme.name
 
-    return this.$auth.$storage.getUniversal(_key)
+    return this.$storage.getUniversal(_key)
   }
 
   _setExpiration (expiration) {
-    const _key = this.$auth.options.refreshTokenExpiration.prefix + this.$auth.strategy.name
+    const _key = this.scheme.options.refreshToken.expirationPrefix + this.scheme.name
 
-    return this.$auth.$storage.setUniversal(_key, expiration)
+    return this.$storage.setUniversal(_key, expiration)
   }
 
   _syncExpiration () {
-    const _key = this.$auth.options.refreshTokenExpiration.prefix + this.$auth.strategy.name
+    const _key = this.scheme.options.refreshToken.expirationPrefix + this.scheme.name
 
-    return this.$auth.$storage.syncUniversal(_key)
+    return this.$storage.syncUniversal(_key)
   }
 
   _updateExpiration (refreshToken) {
     let refreshTokenExpiration
     const _tokenIssuedAtMillis = Date.now()
-    const _tokenTTLMillis = this.$auth.strategy.options.refreshToken.maxAge * 1000
+    const _tokenTTLMillis = this.scheme.options.refreshToken.maxAge * 1000
     const _tokenExpiresAtMillis = _tokenTTLMillis ? _tokenIssuedAtMillis + _tokenTTLMillis : 0
 
     try {
@@ -50,25 +53,25 @@ export default class RefreshToken {
   }
 
   _setToken (refreshToken) {
-    const _key = this.$auth.options.refreshToken.prefix + this.$auth.strategy.name
+    const _key = this.scheme.options.refreshToken.prefix + this.scheme.name
 
-    return this.$auth.$storage.setUniversal(_key, refreshToken)
+    return this.$storage.setUniversal(_key, refreshToken)
   }
 
   _syncToken () {
-    const _key = this.$auth.options.refreshToken.prefix + this.$auth.strategy.name
+    const _key = this.scheme.options.refreshToken.prefix + this.scheme.name
 
-    return this.$auth.$storage.syncUniversal(_key)
+    return this.$storage.syncUniversal(_key)
   }
 
   get () {
-    const _key = this.$auth.options.refreshToken.prefix + this.$auth.strategy.name
+    const _key = this.scheme.options.refreshToken.prefix + this.scheme.name
 
-    return this.$auth.$storage.getUniversal(_key)
+    return this.$storage.getUniversal(_key)
   }
 
   set (tokenValue) {
-    const refreshToken = addTokenPrefix(tokenValue, this.$auth.strategy.options.refreshToken.type)
+    const refreshToken = addTokenPrefix(tokenValue, this.scheme.options.refreshToken.type)
 
     this._setToken(refreshToken)
     this._updateExpiration(refreshToken)

--- a/src/inc/request-handler.ts
+++ b/src/inc/request-handler.ts
@@ -5,12 +5,12 @@ import ExpiredAuthSessionError from './expired-auth-session-error'
 
 export default class RequestHandler {
   public scheme: Scheme
-  public $axios: NuxtAxiosInstance
+  public axios: NuxtAxiosInstance
   public interceptor: any
 
   constructor (scheme, axios) {
     this.scheme = scheme
-    this.$axios = axios
+    this.axios = axios
     this.interceptor = null
   }
 
@@ -32,14 +32,14 @@ export default class RequestHandler {
   setHeader (token) {
     if (this.scheme.options.token.global) {
       // Set Authorization token for all axios requests
-      this.$axios.setHeader(this.scheme.options.token.name, token)
+      this.axios.setHeader(this.scheme.options.token.name, token)
     }
   }
 
   clearHeader () {
     if (this.scheme.options.token.global) {
       // Clear Authorization token for all axios requests
-      this.$axios.setHeader(this.scheme.options.token.name, false)
+      this.axios.setHeader(this.scheme.options.token.name, false)
     }
   }
 
@@ -48,7 +48,7 @@ export default class RequestHandler {
   // Refresh tokens if token has expired
   // ---------------------------------------------------------------
   initializeRequestInterceptor (refreshEndpoint?: string) {
-    this.interceptor = this.$axios.interceptors.request.use(async (config) => {
+    this.interceptor = this.axios.interceptors.request.use(async (config) => {
       // Don't intercept refresh token requests
       if (!this._needToken(config) || config.url === refreshEndpoint) {
         return config
@@ -97,7 +97,7 @@ export default class RequestHandler {
 
   reset () {
     // Eject request interceptor
-    this.$axios.interceptors.request.eject(this.interceptor)
+    this.axios.interceptors.request.eject(this.interceptor)
     this.interceptor = null
   }
 }

--- a/src/inc/request-handler.ts
+++ b/src/inc/request-handler.ts
@@ -1,6 +1,5 @@
-import type { AxiosRequestConfig } from 'axios'
 import type { NuxtAxiosInstance } from '@nuxtjs/axios'
-import type { Scheme } from '../'
+import type { Scheme, HTTPRequest } from '../'
 import ExpiredAuthSessionError from './expired-auth-session-error'
 
 export default class RequestHandler {
@@ -14,18 +13,18 @@ export default class RequestHandler {
     this.interceptor = null
   }
 
-  _needToken (config: AxiosRequestConfig) {
+  _needToken (config: HTTPRequest) {
     const options = this.scheme.options
     return options.token.global || Object.values(options.endpoints)
-      .some((endpoint: AxiosRequestConfig | string) => typeof endpoint === 'object' ? endpoint.url === config.url : endpoint === config.url)
+      .some((endpoint: HTTPRequest | string) => typeof endpoint === 'object' ? endpoint.url === config.url : endpoint === config.url)
   }
 
-  _getUpdatedRequestConfig (config: AxiosRequestConfig, token) {
+  _getUpdatedRequestConfig (config: HTTPRequest, token) {
     config.headers[this.scheme.options.token.name] = token
     return config
   }
 
-  _requestHasAuthorizationHeader (config: AxiosRequestConfig) {
+  _requestHasAuthorizationHeader (config: HTTPRequest) {
     return !!config.headers.common[this.scheme.options.token.name]
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,12 @@
+import type { AxiosRequestConfig, AxiosResponse } from 'axios'
 import _Auth from './core/auth'
 import _Scheme from './schemes/_scheme'
 import Token from './inc/token'
 import RefreshToken from './inc/refresh-token'
 import RequestHandler from './inc/request-handler'
+
+export { AxiosRequestConfig as HTTPRequest }
+export { AxiosResponse as HTTPResponse }
 
 export type Auth = _Auth
 export type Scheme = _Scheme<SchemeOptions | any> & {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,13 +10,20 @@ export type Scheme = _Scheme<SchemeOptions | any> & {
   refreshToken?: RefreshToken
   requestHandler?: RequestHandler
   refreshTokens?: Function
-  check?: (checkStatus: boolean, tokenCallback?: (isRefreshable: boolean) => boolean | void, refreshTokenCallback?: () => boolean | void) => boolean | Promise<boolean>
+  check?: (checkStatus: boolean) => SchemeCheck
   reset?: Function
 }
 
 export type SchemeOptions = {
   name: string,
   [key: string]: any
+}
+
+export type SchemeCheck = {
+  valid: boolean
+  tokenExpired?: boolean
+  refreshTokenExpired?: boolean
+  isRefreshable?: boolean
 }
 
 export type AuthOptions = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,22 +1,17 @@
 import _Auth from './core/auth'
 import _Scheme from './schemes/_scheme'
+import Token from './inc/token'
+import RefreshToken from './inc/refresh-token'
+import RequestHandler from './inc/request-handler'
 
 export type Auth = _Auth
 export type Scheme = _Scheme<SchemeOptions | any> & {
-  refreshTokens: Function
-  check: () => boolean
-}
-
-export type HTTPRequest = {
-  method?: 'get' | 'post' | string
-  url?: string,
-  baseURL?: boolean
-  data?: object | any,
-  headers?: { [name: string]: string }
-}
-
-export type HTTPResponse = {
-  data: object | any
+  token?: Token,
+  refreshToken?: RefreshToken
+  requestHandler?: RequestHandler
+  refreshTokens?: Function
+  check?: (checkStatus: boolean, tokenCallback?: (isRefreshable: boolean) => boolean | void, refreshTokenCallback?: () => boolean | void) => boolean | Promise<boolean>
+  reset?: Function
 }
 
 export type SchemeOptions = {
@@ -32,12 +27,6 @@ export type AuthOptions = {
   fullPathRedirect: boolean
   scopeKey: string
   redirect: { [from: string]: string }
-
-  // TODO: Token options and handling should be from scheme
-  token: { prefix: string, type: string }
-  tokenExpiration: { prefix: string }
-  refreshToken: { prefix: string }
-  refreshTokenExpiration: { prefix: string }
 }
 
 declare module '@nuxt/types' {

--- a/src/module/defaults.ts
+++ b/src/module/defaults.ts
@@ -43,26 +43,6 @@ export default {
     prefix: 'auth.'
   },
 
-  // -- Tokens --
-
-  token: {
-    prefix: '_token.'
-  },
-
-  tokenExpiration: {
-    prefix: '_token_expiration.'
-  },
-
-  // -- Refresh token --
-
-  refreshToken: {
-    prefix: '_refresh_token.'
-  },
-
-  refreshTokenExpiration: {
-    prefix: '_refresh_token_expiration.'
-  },
-
   // -- Strategies --
 
   defaultStrategy: undefined /* will be auto set at module level */,

--- a/src/providers/laravel/passport.ts
+++ b/src/providers/laravel/passport.ts
@@ -33,10 +33,10 @@ export default function laravelPassport (nuxt, strategy) {
       endpoints: {
         token: url + '/oauth/token',
         login: {
-          baseURL: process.server ? undefined : false
+          baseURL: ''
         },
         refresh: {
-          baseURL: process.server ? undefined : false
+          baseURL: ''
         },
         logout: false,
         user: {

--- a/src/schemes/cookie.ts
+++ b/src/schemes/cookie.ts
@@ -1,3 +1,4 @@
+import type { SchemeCheck } from '../index'
 import LocalScheme from './local'
 
 const DEFAULTS = {
@@ -29,17 +30,21 @@ export default class CookieScheme extends LocalScheme {
     return super.mounted()
   }
 
-  check () {
-    if (!super.check()) {
-      return false
+  check (): SchemeCheck {
+    const response = { valid: false }
+
+    if (!super.check().valid) {
+      return response
     }
 
     if (this.options.cookie.name) {
       const cookies = this.$auth.$storage.getCookies()
-      return Boolean(cookies[this.options.cookie.name])
+      response.valid = Boolean(cookies[this.options.cookie.name])
+      return response
     }
 
-    return true
+    response.valid = true
+    return response
   }
 
   async login (endpoint) {

--- a/src/schemes/local.ts
+++ b/src/schemes/local.ts
@@ -1,8 +1,7 @@
-import type { AxiosRequestConfig } from 'axios'
 import { getProp, getResponseProp } from '../utils'
 import Token from '../inc/token'
 import RequestHandler from '../inc/request-handler'
-import type { SchemeCheck, SchemeOptions } from '../'
+import type { SchemeCheck, SchemeOptions, HTTPRequest } from '../'
 import BaseScheme from './_scheme'
 
 const DEFAULTS: SchemeOptions = {
@@ -187,7 +186,7 @@ export default class LocalScheme extends BaseScheme<typeof DEFAULTS> {
     })
   }
 
-  async logout (endpoint: AxiosRequestConfig = {}) {
+  async logout (endpoint: HTTPRequest = {}) {
     // Only connect to logout endpoint if it's configured
     if (this.options.endpoints.logout) {
       await this.$auth

--- a/src/schemes/oauth2.ts
+++ b/src/schemes/oauth2.ts
@@ -335,7 +335,7 @@ export default class Oauth2Scheme extends BaseScheme<typeof DEFAULTS> {
       method: 'post',
       url: this.options.endpoints.token,
       data: encodeQuery({
-        refresh_token: removeTokenPrefix(refreshToken, this.$auth.options.token.type),
+        refresh_token: removeTokenPrefix(refreshToken, this.options.token.type),
         client_id: this.options.clientId,
         grant_type: 'refresh_token'
       })

--- a/src/schemes/oauth2.ts
+++ b/src/schemes/oauth2.ts
@@ -4,6 +4,8 @@ import { encodeQuery, parseQuery, normalizePath, getResponseProp, urlJoin, remov
 import RefreshController from '../inc/refresh-controller'
 import RequestHandler from '../inc/request-handler'
 import ExpiredAuthSessionError from '../inc/expired-auth-session-error'
+import Token from '../inc/token'
+import RefreshToken from '../inc/refresh-token'
 import BaseScheme from './_scheme'
 
 const DEFAULTS = {
@@ -29,11 +31,15 @@ const DEFAULTS = {
     type: 'Bearer',
     name: 'Authorization',
     maxAge: 1800,
-    global: true
+    global: true,
+    prefix: '_token.',
+    expirationPrefix: '_token_expiration.'
   },
   refreshToken: {
     property: 'refresh_token',
-    maxAge: 60 * 60 * 24 * 30
+    maxAge: 60 * 60 * 24 * 30,
+    prefix: '_refresh_token.',
+    expirationPrefix: '_refresh_token_expiration.'
   },
   responseType: 'token',
   codeChallengeMethod: 'implicit'
@@ -42,6 +48,8 @@ const DEFAULTS = {
 export default class Oauth2Scheme extends BaseScheme<typeof DEFAULTS> {
   public req
   public name
+  public token: Token
+  public refreshToken: RefreshToken
   public refreshController: RefreshController
   public requestHandler: RequestHandler
 
@@ -50,8 +58,17 @@ export default class Oauth2Scheme extends BaseScheme<typeof DEFAULTS> {
 
     this.req = $auth.ctx.req
 
+    // Initialize Token instance
+    this.token = new Token(this, this.$auth.$storage)
+
+    // Initialize Refresh Token instance
+    this.refreshToken = new RefreshToken(this, this.$auth.$storage)
+
+    // Initialize Refresh Controller
     this.refreshController = new RefreshController(this)
-    this.requestHandler = new RequestHandler(this.$auth)
+
+    // Initialize Request Handler
+    this.requestHandler = new RequestHandler(this, this.$auth.ctx.$axios)
   }
 
   get _scope () {
@@ -72,33 +89,61 @@ export default class Oauth2Scheme extends BaseScheme<typeof DEFAULTS> {
     const token = getResponseProp(response, this.options.token.property)
     const refreshToken = getResponseProp(response, this.options.refreshToken.property)
 
-    this.$auth.token.set(token)
+    this.token.set(token)
 
     if (refreshToken) {
-      this.$auth.refreshToken.set(refreshToken)
+      this.refreshToken.set(refreshToken)
     }
   }
 
-  _checkStatus () {
+  check (checkStatus = false, tokenCallback?, refreshTokenCallback?) {
     // Sync tokens
-    this.$auth.token.sync()
-    this.$auth.refreshToken.sync()
+    const token = this.token.sync()
+    this.refreshToken.sync()
 
-    // Get token and refresh token status
-    const tokenStatus = this.$auth.token.status()
-    const refreshTokenStatus = this.$auth.refreshToken.status()
-
-    // Force reset if refresh token has expired
-    // Or if `autoLogout` is enabled and token has expired
-    if (refreshTokenStatus.expired()) {
-      this.$auth.reset()
-    } else if (this.options.autoLogout && tokenStatus.expired()) {
-      this.$auth.reset()
+    // Token is required but not available
+    if (!token) {
+      return false
     }
+
+    // Check status wasn't enabled, let it pass
+    if (!checkStatus) {
+      return true
+    }
+
+    // Get status
+    const tokenStatus = this.token.status()
+    const refreshTokenStatus = this.refreshToken.status()
+
+    // Refresh token has expired. There is no way to refresh. Force reset.
+    if (refreshTokenStatus.expired()) {
+      if (typeof refreshTokenCallback === 'function') {
+        return refreshTokenCallback() || false
+      }
+
+      return false
+    }
+
+    // Token has expired, Force reset.
+    if (tokenStatus.expired()) {
+      if (typeof tokenCallback === 'function') {
+        return tokenCallback(true) || false
+      }
+
+      return false
+    }
+
+    return true
   }
 
   async mounted () {
-    this._checkStatus()
+    this.check(true, () => {
+      if (this.options.autoLogout) {
+        this.$auth.reset()
+      }
+    }, () => {
+      this.$auth.reset()
+    })
 
     // Initialize request interceptor
     this.requestHandler.initializeRequestInterceptor(this.options.endpoints.token)
@@ -111,14 +156,14 @@ export default class Oauth2Scheme extends BaseScheme<typeof DEFAULTS> {
     }
   }
 
-  check () {
-    return !!this.$auth.token.get()
-  }
-
-  reset () {
+  reset ({ resetInterceptor = true } = {}) {
     this.$auth.setUser(false)
-    this.$auth.token.reset()
-    this.$auth.refreshToken.reset()
+    this.token.reset()
+    this.refreshToken.reset()
+
+    if (resetInterceptor) {
+      this.requestHandler.reset()
+    }
     this.requestHandler.reset()
   }
 
@@ -278,7 +323,7 @@ export default class Oauth2Scheme extends BaseScheme<typeof DEFAULTS> {
       const response = await this.$auth.request({
         method: 'post',
         url: this.options.endpoints.token,
-        baseURL: process.server ? undefined : false,
+        baseURL: '',
         data: encodeQuery({
           code: parsedQuery.code,
           client_id: this.options.clientId,
@@ -299,11 +344,11 @@ export default class Oauth2Scheme extends BaseScheme<typeof DEFAULTS> {
     }
 
     // Set token
-    this.$auth.token.set(token)
+    this.token.set(token)
 
     // Store refresh token
     if (refreshToken && refreshToken.length) {
-      this.$auth.refreshToken.set(refreshToken)
+      this.refreshToken.set(refreshToken)
     }
 
     // Redirect to home
@@ -314,13 +359,13 @@ export default class Oauth2Scheme extends BaseScheme<typeof DEFAULTS> {
 
   async refreshTokens () {
     // Get refresh token
-    const refreshToken = this.$auth.refreshToken.get()
+    const refreshToken = this.refreshToken.get()
 
     // Refresh token is required but not available
     if (!refreshToken) { return }
 
     // Get refresh token status
-    const refreshTokenStatus = this.$auth.refreshToken.status()
+    const refreshTokenStatus = this.refreshToken.status()
 
     // Refresh token is expired. There is no way to refresh. Force reset.
     if (refreshTokenStatus.expired()) {

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -49,7 +49,7 @@ describe('e2e', () => {
 
       return {
         axiosBearer: window.$nuxt.$axios.defaults.headers.common.Authorization,
-        token: window.$nuxt.$auth.token.get(),
+        token: window.$nuxt.$auth.strategy.token.get(),
         user: window.$nuxt.$auth.user,
         response
       }
@@ -85,9 +85,9 @@ describe('e2e', () => {
 
       return {
         loginAxiosBearer: window.$nuxt.$axios.defaults.headers.common.Authorization,
-        loginToken: window.$nuxt.$auth.token.get(),
-        loginRefreshToken: window.$nuxt.$auth.refreshToken.get(),
-        loginExpiresAt: window.$nuxt.$auth.token._getExpiration(),
+        loginToken: window.$nuxt.$auth.strategy.token.get(),
+        loginRefreshToken: window.$nuxt.$auth.strategy.refreshToken.get(),
+        loginExpiresAt: window.$nuxt.$auth.strategy.token._getExpiration(),
         loginUser: window.$nuxt.$auth.user,
         loginResponse
       }
@@ -115,9 +115,9 @@ describe('e2e', () => {
 
       return {
         refreshedAxiosBearer: window.$nuxt.$axios.defaults.headers.common.Authorization,
-        refreshedToken: window.$nuxt.$auth.token.get(),
-        refreshedRefreshToken: window.$nuxt.$auth.refreshToken.get(),
-        refreshedExpiresAt: window.$nuxt.$auth.token._getExpiration(),
+        refreshedToken: window.$nuxt.$auth.strategy.token.get(),
+        refreshedRefreshToken: window.$nuxt.$auth.strategy.refreshToken.get(),
+        refreshedExpiresAt: window.$nuxt.$auth.strategy.token._getExpiration(),
         refreshedUser: window.$nuxt.$auth.user,
         refreshedResponse
       }
@@ -152,7 +152,7 @@ describe('e2e', () => {
 
       return {
         loginAxiosBearer: window.$nuxt.$axios.defaults.headers.common.Authorization,
-        loginToken: window.$nuxt.$auth.token.get()
+        loginToken: window.$nuxt.$auth.strategy.token.get()
       }
     })
 
@@ -164,7 +164,7 @@ describe('e2e', () => {
 
       return {
         logoutAxiosBearer: window.$nuxt.$axios.defaults.headers.common.Authorization,
-        logoutToken: window.$nuxt.$auth.token.get()
+        logoutToken: window.$nuxt.$auth.strategy.token.get()
       }
     })
 


### PR DESCRIPTION
Initialize Token and Refresh Token instances inside schemes. Both classes now use scheme options instead of `$auth`. Also move token and refresh token prefixes to scheme `DEFAULTS`.

Improve `check` method to also check tokens status, deprecating `_checkStatus`. Return object with token and refresh token expired status.
```js
{
  valid: boolean,
  tokenExpired: boolean,
  refreshTokenExpired: boolean,
  isRefreshable: boolean
}
```
**Note:** `valid` is the only required property.

Alias `HTTPRequest` to `AxiosRequestConfig` and `HTTPResponse` to `AxiosResponse`.

RequestHandler class now use scheme options and methods instead of `$auth`.