### PR TITLE
fix(request handler): only intercept requests if global token is enabled

### DIFF
--- a/src/inc/request-handler.ts
+++ b/src/inc/request-handler.ts
@@ -4,6 +4,11 @@ import ExpiredAuthSessionError from './expired-auth-session-error'
 export default class RequestHandler {
   constructor (public $auth: Auth) {}
 
+  _needToken (config: HTTPRequest) {
+    const options = this.$auth.strategy.options;
+    return options.token.global || Object.values(options.endpoints).includes(config.url)
+  }
+
   _getUpdatedRequestConfig (config: HTTPRequest) {
     config.headers[this.$auth.strategy.options.token.name] = this.$auth.token.get()
     return config
@@ -34,7 +39,7 @@ export default class RequestHandler {
   initializeRequestInterceptor (refreshEndpoint?: string) {
     this.$auth.ctx.app.$axios.onRequest(async (config) => {
       // Don't intercept refresh token requests
-      if (config.url === refreshEndpoint) {
+      if (!this._needToken(config) || config.url === refreshEndpoint ) {
         return config
       }
 

--- a/src/inc/request-handler.ts
+++ b/src/inc/request-handler.ts
@@ -7,7 +7,7 @@ export default class RequestHandler {
   _needToken (config: HTTPRequest) {
     const options = this.$auth.strategy.options
     return options.token.global || Object.values(options.endpoints)
-      .some(endpoint => typeof endpoint === 'object' ? endpoint.url === config.url : endpoint === config.url)
+      .some((endpoint: HTTPRequest | string) => typeof endpoint === 'object' ? endpoint.url === config.url : endpoint === config.url)
   }
 
   _getUpdatedRequestConfig (config: HTTPRequest) {

--- a/src/inc/request-handler.ts
+++ b/src/inc/request-handler.ts
@@ -6,7 +6,8 @@ export default class RequestHandler {
 
   _needToken (config: HTTPRequest) {
     const options = this.$auth.strategy.options
-    return options.token.global || Object.values(options.endpoints).includes(config.url)
+    return options.token.global || Object.values(options.endpoints)
+      .some(endpoint => typeof endpoint === 'object' ? endpoint.url === config.url : endpoint === config.url)
   }
 
   _getUpdatedRequestConfig (config: HTTPRequest) {

--- a/src/inc/request-handler.ts
+++ b/src/inc/request-handler.ts
@@ -5,7 +5,7 @@ export default class RequestHandler {
   constructor (public $auth: Auth) {}
 
   _needToken (config: HTTPRequest) {
-    const options = this.$auth.strategy.options;
+    const options = this.$auth.strategy.options
     return options.token.global || Object.values(options.endpoints).includes(config.url)
   }
 
@@ -39,7 +39,7 @@ export default class RequestHandler {
   initializeRequestInterceptor (refreshEndpoint?: string) {
     this.$auth.ctx.app.$axios.onRequest(async (config) => {
       // Don't intercept refresh token requests
-      if (!this._needToken(config) || config.url === refreshEndpoint ) {
+      if (!this._needToken(config) || config.url === refreshEndpoint) {
         return config
       }
 


### PR DESCRIPTION
This change is needed for using other api's auth because the onRequest is called on each request made with axios so each auth of others api's requests are override by the module token.