### PR TITLE
feat(oauth2): make nonce settable when response_type includes 'token'

### DIFF
--- a/src/schemes/oauth2.ts
+++ b/src/schemes/oauth2.ts
@@ -257,7 +257,7 @@ export class Oauth2Scheme<
     // Set Nonce Value if response_type contains id_token to mitigate Replay Attacks
     // More Info: https://openid.net/specs/openid-connect-core-1_0.html#NonceNotes
     // More Info: https://tools.ietf.org/html/draft-ietf-oauth-v2-threatmodel-06#section-4.6.2
-    if (opts.response_type.includes('id_token')) {
+    if (opts.response_type.includes('token')) {
       opts.nonce = _opts.nonce || randomString(10)
     }
 


### PR DESCRIPTION
Keycloak required nonce for response_type=token but there was no way I was able to set nonce.