### PR TITLE
fix(refresh scheme): fix non-required refresh token flow

### DIFF
--- a/src/providers/laravel/jwt/index.ts
+++ b/src/providers/laravel/jwt/index.ts
@@ -1,4 +1,5 @@
-import { assignDefaults, assignAbsoluteEndpoints } from '../../utils/provider'
+import path from 'path'
+import { assignDefaults, assignAbsoluteEndpoints } from '../../../utils/provider'
 
 export default function laravelJWT (_nuxt, strategy) {
   const { url } = strategy
@@ -8,7 +9,7 @@ export default function laravelJWT (_nuxt, strategy) {
   }
 
   assignDefaults(strategy, {
-    scheme: 'refresh',
+    scheme: path.resolve(__dirname, 'scheme'),
     name: 'laravelJWT',
     endpoints: {
       login: {

--- a/src/providers/laravel/jwt/scheme.ts
+++ b/src/providers/laravel/jwt/scheme.ts
@@ -1,0 +1,7 @@
+import RefreshScheme from '../../../schemes/refresh'
+
+export default class LaravelJWT extends RefreshScheme {
+  _updateTokens (response, { isRefreshing = false, updateOnRefresh = false } = {}) {
+    super._updateTokens(response, { isRefreshing, updateOnRefresh })
+  }
+}


### PR DESCRIPTION
Set refresh token to `true` instead of `false` if refresh token is not required. That way refresh token expiration is set. And add `isRefreshing` and `updateOnRefresh` params to be able to not update refresh token expiration if refresh endpoint doesn't refresh the refresh token.
Also simplify `check` as refresh token will always be `true` when not required.

Add custom scheme for Laravel JWT provider to not update refresh token expiration on refresh.