### PR TITLE
feat: improve `setUserToken` to set refresh token

### DIFF
--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -178,13 +178,13 @@ export default class Auth {
     })
   }
 
-  setUserToken (token) {
+  setUserToken (token, refreshToken?) {
     if (!this.strategy.setUserToken) {
       this.token.set(token)
       return Promise.resolve()
     }
 
-    return Promise.resolve(this.strategy.setUserToken(token)).catch((error) => {
+    return Promise.resolve(this.strategy.setUserToken(token, refreshToken)).catch((error) => {
       this.callOnError(error, { method: 'setUserToken' })
       return Promise.reject(error)
     })

--- a/src/schemes/local.ts
+++ b/src/schemes/local.ts
@@ -1,4 +1,4 @@
-import { getProp, getResponseProp } from '../utils'
+import { getResponseProp } from '../utils'
 import RequestHandler from '../inc/request-handler'
 import type { SchemeOptions, HTTPRequest } from '../'
 import BaseScheme from './_scheme'
@@ -127,8 +127,8 @@ export default class LocalScheme extends BaseScheme<typeof DEFAULTS> {
     return response
   }
 
-  async setUserToken (tokenValue) {
-    this.$auth.token.set(getProp(tokenValue, this.options.token.property))
+  async setUserToken (token) {
+    this.$auth.token.set(token)
 
     // Fetch user
     return this.fetchUser()

--- a/src/schemes/refresh.ts
+++ b/src/schemes/refresh.ts
@@ -170,10 +170,10 @@ export default class RefreshScheme extends LocalScheme {
   }
 
   async setUserToken (token, refreshToken?) {
-    this.$auth.token.set(token)
+    this.token.set(token)
 
     if (refreshToken) {
-      this.$auth.refreshToken.set(refreshToken)
+      this.refreshToken.set(refreshToken)
     }
 
     // Fetch user

--- a/src/schemes/refresh.ts
+++ b/src/schemes/refresh.ts
@@ -136,6 +136,17 @@ export default class RefreshScheme extends LocalScheme {
     })
   }
 
+  async setUserToken (token, refreshToken?) {
+    this.$auth.token.set(token)
+
+    if (refreshToken) {
+      this.$auth.refreshToken.set(refreshToken)
+    }
+
+    // Fetch user
+    return this.fetchUser()
+  }
+
   reset ({ resetInterceptor = true } = {}) {
     this.$auth.setUser(false)
     this.$auth.token.reset()


### PR DESCRIPTION
Improve `setUserToken` to set refresh token as second parameter and fix `setUserToken` of `local` scheme.