### PR TITLE
refactor(local, refresh): add method `_initializeRequestInterceptor`

### DIFF
--- a/src/schemes/local.ts
+++ b/src/schemes/local.ts
@@ -67,11 +67,15 @@ export default class LocalScheme extends BaseScheme<typeof DEFAULTS> {
     }
   }
 
-  mounted ({ refreshEndpoint = undefined } = {}) {
+  _initializeRequestInterceptor () {
+    this.requestHandler.initializeRequestInterceptor()
+  }
+
+  mounted () {
     this._checkStatus()
 
     // Initialize request interceptor
-    this.requestHandler.initializeRequestInterceptor(refreshEndpoint)
+    this._initializeRequestInterceptor()
 
     // Fetch user once
     return this.$auth.fetchUserOnce()
@@ -85,7 +89,7 @@ export default class LocalScheme extends BaseScheme<typeof DEFAULTS> {
     return true
   }
 
-  async login (endpoint, { reset = true, refreshEndpoint = undefined } = {}) {
+  async login (endpoint, { reset = true } = {}) {
     if (!this.options.endpoints.login) {
       return
     }
@@ -116,7 +120,7 @@ export default class LocalScheme extends BaseScheme<typeof DEFAULTS> {
 
     // Initialize request interceptor if not initialized
     if (!this.requestHandler.interceptor) {
-      this.requestHandler.initializeRequestInterceptor(refreshEndpoint)
+      this._initializeRequestInterceptor()
     }
 
     // Fetch user if `autoFetch` is enabled

--- a/src/schemes/refresh.ts
+++ b/src/schemes/refresh.ts
@@ -59,8 +59,8 @@ export default class RefreshScheme extends LocalScheme {
     }
   }
 
-  mounted ({ refreshEndpoint = this.options.endpoints.refresh.url } = {}) {
-    return super.mounted({ refreshEndpoint })
+  _initializeRequestInterceptor () {
+    this.requestHandler.initializeRequestInterceptor(this.options.endpoints.refresh.url)
   }
 
   check () {
@@ -75,10 +75,6 @@ export default class RefreshScheme extends LocalScheme {
     }
 
     return true
-  }
-
-  async login (endpoint, { reset = true, refreshEndpoint = this.options.endpoints.refresh.url } = {}) {
-    return super.login(endpoint, { reset, refreshEndpoint })
   }
 
   async refreshTokens () {


### PR DESCRIPTION
Using this method makes it easier to set the refresh endpoint. Just need to override it in `refresh` scheme. That way we don't need to pass `refreshEndpoint` everywhere the interceptor is initialized.