### PR TITLE
fix(utils): check if `holder` is `object` in `getProp` util

### DIFF
--- a/lib/core/utilities.js
+++ b/lib/core/utilities.js
@@ -93,7 +93,7 @@ export function decodeValue (val) {
  * @return {*}          A property value
  */
 export function getProp (holder, propName) {
-  if (!propName || (!holder || typeof holder === 'string' || holder instanceof String)) {
+  if (!propName || (!holder || typeof holder !== 'object') {
     return holder
   }
 

--- a/lib/core/utilities.js
+++ b/lib/core/utilities.js
@@ -93,7 +93,7 @@ export function decodeValue (val) {
  * @return {*}          A property value
  */
 export function getProp (holder, propName) {
-  if (!propName || !holder) {
+  if (!propName || (!holder || typeof holder === 'string' || holder instanceof String)) {
     return holder
   }
 


### PR DESCRIPTION
Added a check for both ways a string can be defined. This fixes an exception when the server returns a string instead of an object. See #699 for more information.