### PR TITLE
fix(refresh scheme): add `tokenRequired` option for refresh token

### DIFF
--- a/docs/schemes/refresh.md
+++ b/docs/schemes/refresh.md
@@ -133,10 +133,6 @@ By default is set to 30 minutes.
 
 Here you configure the refresh token options.
 
-#### `required`
-
-In instances where you do not need to refresh the token you can assign `false` to the `required` property. This disables the `refreshToken`.
-
 #### `property`
 
 `property` can be used to specify which field of the response JSON to be used for value. It can be `false` to directly use API response or being more complicated like `auth.refresh_token`.
@@ -156,6 +152,12 @@ This time will be used if for some reason we couldn't decode the token to get th
 You can set it to `false` if your refresh token doesn't expire.
 
 By default is set to 30 minutes.
+
+#### `required`
+
+- Default: `true`
+
+In instances where you do not need the refresh token to perform the refresh, you can assign this option to `false`. This disables the `refreshToken`.
 
 #### `tokenRequired`
 

--- a/docs/schemes/refresh.md
+++ b/docs/schemes/refresh.md
@@ -157,6 +157,12 @@ You can set it to `false` if your refresh token doesn't expire.
 
 By default is set to 30 minutes.
 
+#### `tokenRequired`
+
+- Default: `false`
+
+If enabled, Authorization header won't be cleared before refreshing.
+
 ### `user`
 
 Here you configure the user options.

--- a/src/providers/laravel/jwt/index.ts
+++ b/src/providers/laravel/jwt/index.ts
@@ -33,7 +33,8 @@ export default function laravelJWT (_nuxt, strategy) {
       property: false,
       data: false,
       maxAge: 1209600,
-      required: false
+      required: false,
+      tokenRequired: true
     },
     user: {
       property: false

--- a/src/schemes/refresh.ts
+++ b/src/schemes/refresh.ts
@@ -20,7 +20,7 @@ const DEFAULTS = {
     required: true,
     tokenRequired: false,
     prefix: '_refresh_token.',
-    expirationPrefix: '_refresh_token_expiration.',
+    expirationPrefix: '_refresh_token_expiration.'
   },
   autoLogout: false
 }

--- a/src/schemes/refresh.ts
+++ b/src/schemes/refresh.ts
@@ -18,8 +18,9 @@ const DEFAULTS = {
     data: 'refresh_token',
     maxAge: 60 * 60 * 24 * 30,
     required: true,
+    tokenRequired: false,
     prefix: '_refresh_token.',
-    expirationPrefix: '_refresh_token_expiration.'
+    expirationPrefix: '_refresh_token_expiration.',
   },
   autoLogout: false
 }
@@ -128,8 +129,10 @@ export default class RefreshScheme extends LocalScheme {
       throw new ExpiredAuthSessionError()
     }
 
-    // Delete current token from the request header before refreshing
-    this.requestHandler.clearHeader()
+    // Delete current token from the request header before refreshing, if `tokenRequired` is disabled
+    if (!this.options.refreshToken.tokenRequired) {
+      this.requestHandler.clearHeader()
+    }
 
     const endpoint = {
       data: {


### PR DESCRIPTION
If `tokenRequired` is enabled, Authorization header won't be cleared before refreshing. Disabled by default.
Also fix Laravel JWT provider by enabling `tokenRequired` option.