### PR TITLE
chore(deps): lock nanoid in v2.1.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "is-https": "^1.0.0",
     "js-cookie": "^2.2.1",
     "lodash": "^4.17.15",
-    "nanoid": "^2.1.11"
+    "nanoid": "2.1.11"
   },
   "devDependencies": {
     "@nuxtjs/toast": "latest",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6950,7 +6950,7 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
 
-nanoid@^2.1.11:
+nanoid@2.1.11:
   version "2.1.11"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.11.tgz#ec24b8a758d591561531b4176a01e3ab4f0f0280"
   integrity sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==


### PR DESCRIPTION
Fixes nanoid import for auth module v4

Fixes #750