### PR TITLE
fix(oauth2 scheme): make options extendable

### DIFF
--- a/src/schemes/oauth2.ts
+++ b/src/schemes/oauth2.ts
@@ -54,8 +54,8 @@ export default class Oauth2Scheme extends BaseScheme<typeof DEFAULTS> {
   public refreshController: RefreshController
   public requestHandler: RequestHandler
 
-  constructor ($auth, options) {
-    super($auth, options, DEFAULTS)
+  constructor ($auth, options, ...defaults) {
+    super($auth, options, ...defaults, DEFAULTS)
 
     this.req = $auth.ctx.req
 


### PR DESCRIPTION
As designed, we cannot add additional options when extending the Oauth2Scheme. To make options extensible, I borrowed code from the LocalScheme implementation which lets us pass the child's default options up to its parent.

