### PR TITLE
docs: fix typo in options

### DIFF
--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -64,7 +64,7 @@ auth: {
 You can disable use of localStorage by setting `localStorage` to `false`, like so:
 
 ```js
-auth {
+auth: {
   localStorage: false
 }
 ```


### PR DESCRIPTION
Fixes typo in JS code for options