### PR TITLE
Update readme Laravel Sanctum add credentials

### DIFF
--- a/docs/content/en/providers/laravel-sanctum.md
+++ b/docs/content/en/providers/laravel-sanctum.md
@@ -27,7 +27,8 @@ auth: {
 ```js
 {
   axios: {
-    proxy: true
+    proxy: true,
+    credentials: true
   },
   proxy: {
     '/laravel': {


### PR DESCRIPTION
Although outside the scope of this package. I would recommend adding this to the docs. Otherwise all follow up Axios request will fail.

**Without** the credentials in Axios:
```javascript
this.$axios.get('/api/test').then(response => {
    console.log(response);
});
```
```
Request URL: http://127.0.0.1:8000/api/test
Status Code: 401 Unauthorized
```

**With** the credentials in Axios:
```javascript
this.$axios.get('/api/test').then(response => {
    console.log(response);
});
```
```
Request URL: http://127.0.0.1:8000/api/test
Status Code: 200 OK
```

Since now the `X-XSRF-TOKEN` is set.

Let me repeat: I get it if this is outside the scope of this package. But I assume that 99.99% of the users who implement this, probably want to do a follow up request with Axios to their api.