### PR TITLE
Fix OAuth scheme ignoring user.property setting

### DIFF
--- a/src/schemes/oauth2.ts
+++ b/src/schemes/oauth2.ts
@@ -279,11 +279,11 @@ export default class Oauth2Scheme extends BaseScheme<typeof DEFAULTS> {
       return
     }
 
-    const { data } = await this.$auth.requestWith(this.name, {
+    const response = await this.$auth.requestWith(this.name, {
       url: this.options.endpoints.userInfo
     })
 
-    this.$auth.setUser(data)
+    this.$auth.setUser(getResponseProp(response, this.options.user.property))
   }
 
   async _handleCallback () {


### PR DESCRIPTION
We recently migrated from Laravel Passport's password grant to standard OAuth and have run into this issue. Our userInfo method returns a user object wrapped in a data parameter. Using the password grant, we were able to user the user.property setting to specify where to find the user object being returned from the server. This broke when we switched schemes. The OAuth scheme currently ignores the user.property setting. This fixes the issue and brings the code closer to what is defined in other schemes.