### PR TITLE
docs(options.md): redirect -> redirects

### DIFF
--- a/docs/content/en/api/options.md
+++ b/docs/content/en/api/options.md
@@ -13,7 +13,7 @@ Default:
 
 ```js
 auth: {
-  redirect: {
+  redirects: {
     login: '/login',
     logout: '/',
     callback: '/login',


### PR DESCRIPTION
The docs for options say "redirect".
"redirect" does not work, the correct option is "redirects"