### PR TITLE
fix(oauth refresh): OAuth2 scheme token refresh not working server-side and silently errors out

### DIFF
--- a/src/schemes/oauth2.ts
+++ b/src/schemes/oauth2.ts
@@ -1,6 +1,6 @@
 import { nanoid } from 'nanoid'
 import requrl from 'requrl'
-import { encodeQuery, parseQuery, normalizePath, getResponseProp, urlJoin, removeTokenPrefix } from '../utils'
+import { encodeQuery, parseQuery, normalizePath, getResponseProp, urlJoin, removeTokenPrefix, getMatchedComponents } from '../utils'
 import RefreshController from '../inc/refresh-controller'
 import RequestHandler from '../inc/request-handler'
 import ExpiredAuthSessionError from '../inc/expired-auth-session-error'
@@ -380,6 +380,9 @@ export default class Oauth2Scheme extends BaseScheme<typeof DEFAULTS> {
     const response = await this.$auth.request(this.name, {
       method: 'post',
       url: this.options.endpoints.token,
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
       data: encodeQuery({
         refresh_token: removeTokenPrefix(refreshToken, this.options.token.type),
         client_id: this.options.clientId,

--- a/src/schemes/oauth2.ts
+++ b/src/schemes/oauth2.ts
@@ -1,6 +1,6 @@
 import { nanoid } from 'nanoid'
 import requrl from 'requrl'
-import { encodeQuery, parseQuery, normalizePath, getResponseProp, urlJoin, removeTokenPrefix, getMatchedComponents } from '../utils'
+import { encodeQuery, parseQuery, normalizePath, getResponseProp, urlJoin, removeTokenPrefix } from '../utils'
 import RefreshController from '../inc/refresh-controller'
 import RequestHandler from '../inc/request-handler'
 import ExpiredAuthSessionError from '../inc/expired-auth-session-error'


### PR DESCRIPTION
I noticed when using the built-in "oauth2" scheme that if you reload the page with an active refresh token and an expired access token that I would still be logged out and thrown into the login screen again. Upon further digging the content-type request header is missing for server-side access_token refresh.