### PR TITLE
Fixed token type of laravel sanctum scheme

### DIFF
--- a/src/providers/laravel/sanctum.ts
+++ b/src/providers/laravel/sanctum.ts
@@ -42,6 +42,9 @@ export default function laravelSanctum (_nuxt, strategy) {
     },
     user: {
       property: false
+    },
+    token: {
+      type: 'Bearer'
     }
   })
 


### PR DESCRIPTION
https://laravel.com/docs/8.x/sanctum#issuing-api-tokens

> Sanctum allows you to issue API tokens / personal access tokens that may be used to authenticate API requests. When making requests using API tokens, the token should be included in the `Authorization` header as a `Bearer` token.