### PR TITLE
repair "restore strategy" after reloading the page

### DIFF
--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -34,7 +34,8 @@ export default class Auth {
     }
 
     // Restore strategy
-    this.$storage.syncUniversal('strategy', this.options.defaultStrategy)
+    const previous_strategy = window.localStorage.getItem("auth.strategy")
+    this.$storage.syncUniversal('strategy', previous_strategy)
 
     // Set default strategy if current one is invalid
     if (!this.strategy) {


### PR DESCRIPTION
Before this change => after reloading the page there was set "default Strategy", which is "local" by default
After this change => strategy is loading from localstorage, and if there is no strategy, there is seted default one