### PR TITLE
fix(oauth): nanoid import

### DIFF
--- a/lib/schemes/oauth2.js
+++ b/lib/schemes/oauth2.js
@@ -1,5 +1,5 @@
 import { encodeQuery, parseQuery, normalizePath } from '../core/utilities'
-import nanoid from 'nanoid'
+import { nanoid } from 'nanoid'
 const isHttps = process.server ? require('is-https') : null
 
 const DEFAULTS = {


### PR DESCRIPTION
Fix nanoid import as verified by https://github.com/nuxt-community/auth-module/issues/750#issuecomment-652149593 and https://github.com/nuxt-community/auth-module/pull/751#issuecomment-661398859 and https://github.com/nuxt-community/auth-module/issues/772#issuecomment-662886676

Closes https://github.com/nuxt-community/auth-module/issues/750
Closes #772
Closes https://github.com/nuxt-community/auth-module/issues/812
Closes https://github.com/nuxt-community/auth-module/pull/751 (superseded)