### PR TITLE
demo: add express-jwt algorithms

### DIFF
--- a/demo/api/auth.js
+++ b/demo/api/auth.js
@@ -14,7 +14,8 @@ app.use(bodyParser.json())
 // JWT middleware
 app.use(
   jwt({
-    secret: 'dummy'
+    secret: 'dummy',
+    algorithms: ['sha1', 'RS256', 'HS256']
   }).unless({
     path: ['/api/auth/login', '/api/auth/refresh']
   })


### PR DESCRIPTION
This PR fix the error `algorithms should be set` of `express-jwt` (**v5**)