### PR TITLE
update scheme documentation where user.property documentation needs updated

### DIFF
--- a/docs/content/en/schemes/local.md
+++ b/docs/content/en/schemes/local.md
@@ -159,7 +159,7 @@ Here you configure the user options.
 
 #### `property`
 
-`property` can be used to specify which field of the response JSON to be used for value. It can be `false` to directly use API response or being more complicated like `auth.user`.
+`property` can be used to specify which field of the response JSON to be used for value. It can be `false` to disable this feature, `'.'` to directly use API response, or be more complicated like `auth.user`.
 
 #### `autoFetch`
 

--- a/docs/content/en/schemes/refresh.md
+++ b/docs/content/en/schemes/refresh.md
@@ -176,7 +176,7 @@ Here you configure the user options.
 
 #### `property`
 
-`property` can be used to specify which field of the response JSON to be used for value. It can be `false` to directly use API response or being more complicated like `auth.user`.
+`property` can be used to specify which field of the response JSON to be used for value. It can be `false` to disable this feature, `'.'` to directly use API response, or be more complicated like `auth.user`.
  
 #### `autoFetch`
  


### PR DESCRIPTION
This changes the documentation so that False is understood for `user.property` for local/refresh schemes as disable.. and `'.'` is understood as the root of the JSON reply.