### PR TITLE
fix(core): error handling for token refresh in middleware

### DIFF
--- a/src/core/middleware.ts
+++ b/src/core/middleware.ts
@@ -52,7 +52,7 @@ export const authMiddleware: Middleware = async (ctx) => {
         // Refresh token is available. Attempt refresh.
         try {
           await ctx.$auth.refreshTokens()
-        } catch(error) {
+        } catch (error) {
           // Reset when refresh was not successfull
           ctx.$auth.reset()
         }


### PR DESCRIPTION
Fixes an unhandled exception when the middleware tries to refresh the token but the http-request fails.