### PR TITLE
fix(oauth2 scheme): unset baseURL in refreshTokens

### DIFF
--- a/src/schemes/oauth2.ts
+++ b/src/schemes/oauth2.ts
@@ -449,6 +449,7 @@ export class Oauth2Scheme<
       .request({
         method: 'post',
         url: this.options.endpoints.token,
+        baseURL: '',
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded'
         },


### PR DESCRIPTION
While _handleCallback has unset the baseURL when calling the token endpoint, refreshTokens currently uses the existing Axios baseURL.
This causes issues in cases where addAuthorize was used (i.e. the github strategy) as the new token endpoint becomes a relative URL pointing to the Nuxt server middleware.