### PR TITLE
feat(local scheme): set user using login response when `autoFetch` is disabled

### DIFF
--- a/src/schemes/local.ts
+++ b/src/schemes/local.ts
@@ -186,6 +186,12 @@ export class LocalScheme<
     // Fetch user if `autoFetch` is enabled
     if (this.options.user.autoFetch) {
       await this.fetchUser()
+    } else {
+      const user = getResponseProp(response, this.options.user.property)
+
+      if (user) {
+        this.$auth.setUser(user)
+      }
     }
 
     return response

--- a/src/schemes/local.ts
+++ b/src/schemes/local.ts
@@ -189,7 +189,7 @@ export class LocalScheme<
     } else {
       const user = getResponseProp(response, this.options.user.property)
 
-      if (user) {
+      if (this.check().valid && user) {
         this.$auth.setUser(user)
       }
     }

--- a/src/schemes/refresh.ts
+++ b/src/schemes/refresh.ts
@@ -215,10 +215,9 @@ export class RefreshScheme<
     response: HTTPResponse,
     { isRefreshing = false, updateOnRefresh = true } = {}
   ): void {
-    const token = getResponseProp(
-      response,
-      this.options.token.property
-    ) as string
+    const token = this.options.token.required
+      ? (getResponseProp(response, this.options.token.property) as string)
+      : true
     const refreshToken = this.options.refreshToken.required
       ? (getResponseProp(
           response,


### PR DESCRIPTION
I believe that `autoFetch`  is only disabled when user data is already included in login response. 

In [local scheme docs](https://auth.nuxtjs.org/schemes/local#user) we say: 
`This option can be used to disable user fetch after login. It is useful when your login response already have the user. To manually set the user, use setUser`

So why not set the user automatically? :)