### PR TITLE
fix(utils): check if `holder` is `object` in `getProp` util

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -122,7 +122,7 @@ export function getProp(
   holder: Record<string, any>,
   propName: string | false
 ): unknown {
-  if (!propName || !holder) {
+  if (!propName || !holder || typeof holder !== 'object') {
     return holder
   }
 


### PR DESCRIPTION
Fix "TypeError: Cannot use 'in' operator to search for 'token'"

Thanks to @CraftingGamerTom

Closes #699, #738