### PR TITLE
fix: only set authorization header when token is string

### DIFF
--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -342,7 +342,12 @@ export class Auth {
     if (!_endpoint.headers) {
       _endpoint.headers = {}
     }
-    if (!_endpoint.headers[tokenName] && isSet(token) && token) {
+    if (
+      !_endpoint.headers[tokenName] &&
+      isSet(token) &&
+      token &&
+      typeof token === 'string'
+    ) {
       _endpoint.headers[tokenName] = token
     }
 

--- a/src/inc/request-handler.ts
+++ b/src/inc/request-handler.ts
@@ -16,10 +16,10 @@ export class RequestHandler {
     this.interceptor = null
   }
 
-  setHeader(token: string | boolean): void {
+  setHeader(token: string): void {
     if (this.scheme.options.token.global) {
       // Set Authorization token for all axios requests
-      this.axios.setHeader(this.scheme.options.token.name, token + '')
+      this.axios.setHeader(this.scheme.options.token.name, token)
     }
   }
 
@@ -115,7 +115,10 @@ export class RequestHandler {
   // Refresh tokens if token has expired
 
   private _getUpdatedRequestConfig(config, token: string | boolean) {
-    config.headers[this.scheme.options.token.name] = token
+    if (typeof token === 'string') {
+      config.headers[this.scheme.options.token.name] = token
+    }
+
     return config
   }
 

--- a/src/inc/token.ts
+++ b/src/inc/token.ts
@@ -24,8 +24,11 @@ export class Token {
     const token = addTokenPrefix(tokenValue, this.scheme.options.token.type)
 
     this._setToken(token)
-    this.scheme.requestHandler.setHeader(token)
     this._updateExpiration(token)
+
+    if (typeof token === 'string') {
+      this.scheme.requestHandler.setHeader(token)
+    }
 
     return token
   }
@@ -33,7 +36,10 @@ export class Token {
   sync(): string | boolean {
     const token = this._syncToken()
     this._syncExpiration()
-    this.scheme.requestHandler.setHeader(token)
+
+    if (typeof token === 'string') {
+      this.scheme.requestHandler.setHeader(token)
+    }
 
     return token
   }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -158,7 +158,12 @@ export function addTokenPrefix(
   token: string | boolean,
   tokenType: string | false
 ): string | boolean {
-  if (!token || !tokenType || (token + '').startsWith(tokenType)) {
+  if (
+    !token ||
+    !tokenType ||
+    typeof token !== 'string' ||
+    token.startsWith(tokenType)
+  ) {
     return token
   }
 
@@ -169,11 +174,11 @@ export function removeTokenPrefix(
   token: string | boolean,
   tokenType: string | false
 ): string | boolean {
-  if (!token || !tokenType) {
+  if (!token || !tokenType || typeof token !== 'string') {
     return token
   }
 
-  return (token + '').replace(tokenType + ' ', '')
+  return token.replace(tokenType + ' ', '')
 }
 
 export function urlJoin(...args: string[]): string {


### PR DESCRIPTION
When we improved the module types in #922, the axios `setHeader` was complaining about the token not being an string, so I converted it to string using `+ ''`. But it caused an issue when token is set to `false`, as it was converting `false` to string instead of unset the token and authorization header.

Fixes #949 

I couldn't reproduce #945 issue, but seems to be releated to this. So, it possibly fixes #945
After merging, developers facing the issue should test and see if it solves the issue.