### PR TITLE
fix(cookie scheme): use `token.required` instead of `token.property`

### DIFF
--- a/src/schemes/cookie.ts
+++ b/src/schemes/cookie.ts
@@ -28,9 +28,10 @@ const DEFAULTS: SchemePartialOptions<CookieSchemeOptions> = {
   },
   token: {
     type: '',
-    property: '.status',
+    property: '',
     maxAge: false,
-    global: false
+    global: false,
+    required: false
   },
   endpoints: {
     csrf: null


### PR DESCRIPTION
Now that the behaviour when token is not required has been fixed, we can safely use `token.required` set to `false` in cookie flow, instead of using `token.property` set to `.status`

I believe we can also deprecate `getResponseProp` util in another PR. (Use `getProp` instead)