### PR TITLE
docs: fix grammatical error in options documentation

### DIFF
--- a/docs/content/en/api/options.md
+++ b/docs/content/en/api/options.md
@@ -24,7 +24,7 @@ auth: {
 
 * `login`: User will be redirected to this path if *login is required*.
 * `logout`: User will be redirected to this path if *after logout, current route is protected*.
-* `home`: User will be redirect to this path *after login*. (`rewriteRedirects` will rewrite this path)
+* `home`: User will be redirected to this path *after login*. (`rewriteRedirects` will rewrite this path)
 * `callback`: User will be redirected to this path by the identity provider *after login*. (Should match configured `Allowed Callback URLs` (or similar setting) in your app/client with the identity provider)
 
 Each redirect path can be disabled by setting to `false`.


### PR DESCRIPTION
Hi! Loving v5 of this project and my team has been actively using it in a few projects.

I came across this grammatical error a few times and couldn't help but to create a PR for it. Haha.