### PR TITLE
fix: Add error handling for user data fetching

### DIFF
--- a/src/schemes/local.ts
+++ b/src/schemes/local.ts
@@ -214,11 +214,21 @@ export class LocalScheme<
     return this.$auth
       .requestWith(this.name, endpoint, this.options.endpoints.user)
       .then((response) => {
-        this.$auth.setUser(getProp(response.data, this.options.user.property))
+        const userData = getProp(response.data, this.options.user.property)
+
+        if (!userData) {
+          const error = new Error(
+            `User Data response does not contain field ${this.options.user.property}`
+          )
+          return Promise.reject(error)
+        }
+
+        this.$auth.setUser(userData)
         return response
       })
       .catch((error) => {
         this.$auth.callOnError(error, { method: 'fetchUser' })
+        return Promise.reject(error)
       })
   }
 


### PR DESCRIPTION
This PR adds error Handling for 2 Error cases in fetchUser instead of silently failing.

- fetchUser Promise is rejected if the field options.user.property does not contain data in the fetchUser response
- fetchUser Promise is rejected if the Requests Promise was rejected
