### PR TITLE
fix: export main file

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "license": "MIT",
   "sideEffects": "false",
   "exports": {
+    ".": {
+      "require": "./dist/module.js"
+    },
     "./dist/module": {
       "require": "./dist/module.js"
     },


### PR DESCRIPTION
Node 12+ uses  exports field in `package.json` to find main file.  
The main exports was missing in the package.json and it leads to `ERR_PACKAGE_PATH_NOT_EXPORTED` error.

<img width="659" alt="Screen Shot 2021-01-13 at 12 51 17 PM" src="https://user-images.githubusercontent.com/2047945/104127247-42fc2800-5376-11eb-8820-6316d89cc5b5.png">

close #987
