### PR TITLE
fix: Changed package name in the docs

### DIFF
--- a/docs/content/en/status.md
+++ b/docs/content/en/status.md
@@ -12,7 +12,7 @@ Auth module has two major versions to choose from:
 
 This package has more documentation, features and many fixes landed but it's API is still in flux. (current docs)
 
-We recommend that you use v5 via `@nuxt/auth-next`
+We recommend that you use v5 via `@nuxtjs/auth-next`
 
 However, you should fix your `package.json` to the *exact* version of `auth-next` that you develop
 with to avoid updating with breaking changes since package is auto published.


### PR DESCRIPTION
Changed `@nuxt/auth-next` to proper package name: `@nuxtjs/auth-next`