### PR TITLE
fix: laravel sanctum token type

### DIFF
--- a/src/providers/laravel-sanctum.ts
+++ b/src/providers/laravel-sanctum.ts
@@ -59,6 +59,11 @@ export function laravelSanctum(
     },
     user: {
       property: false
+    },
+    token: {
+      // Must be Bearer type:
+      // https://laravel.com/docs/8.x/sanctum#issuing-api-tokens
+      type: 'Bearer'
     }
   }
 


### PR DESCRIPTION
Resolving conflicts from #852

https://laravel.com/docs/8.x/sanctum#issuing-api-tokens

> Sanctum allows you to issue API tokens / personal access tokens that may be used to authenticate API requests. When making requests using API tokens, the token should be included in the `Authorization` header as a `Bearer` token.