### PR TITLE
feat: deprecate `getResponseProp`

### DIFF
--- a/docs/content/en/guide/scheme.md
+++ b/docs/content/en/guide/scheme.md
@@ -65,7 +65,7 @@ export default class CustomScheme extends LocalScheme {
       endpoint,
       this.options.endpoints.user
     ).then((response) => {
-      const user = getResponseProp(response, this.options.user.property)
+      const user = getProp(response.data, this.options.user.property)
       
       // Transform the user object
       const customUser = {

--- a/src/schemes/local.ts
+++ b/src/schemes/local.ts
@@ -9,7 +9,7 @@ import type {
   SchemeCheck
 } from '../types'
 import type { Auth } from '../core'
-import { getResponseProp } from '../utils'
+import { getProp } from '../utils'
 import { Token, RequestHandler } from '../inc'
 import { BaseScheme } from './base'
 
@@ -214,9 +214,7 @@ export class LocalScheme<
     return this.$auth
       .requestWith(this.name, endpoint, this.options.endpoints.user)
       .then((response) => {
-        this.$auth.setUser(
-          getResponseProp(response, this.options.user.property)
-        )
+        this.$auth.setUser(getProp(response.data, this.options.user.property))
         return response
       })
       .catch((error) => {
@@ -249,7 +247,7 @@ export class LocalScheme<
 
   protected updateTokens(response: HTTPResponse): void {
     const token = this.options.token.required
-      ? (getResponseProp(response, this.options.token.property) as string)
+      ? (getProp(response.data, this.options.token.property) as string)
       : true
 
     this.token.set(token)

--- a/src/schemes/oauth2.ts
+++ b/src/schemes/oauth2.ts
@@ -13,7 +13,7 @@ import type {
 import type { Auth } from '../core'
 import {
   encodeQuery,
-  getResponseProp,
+  getProp,
   normalizePath,
   parseQuery,
   removeTokenPrefix,
@@ -327,7 +327,7 @@ export class Oauth2Scheme<
       url: this.options.endpoints.userInfo
     })
 
-    this.$auth.setUser(getResponseProp(response, this.options.user.property))
+    this.$auth.setUser(getProp(response.data, this.options.user.property))
   }
 
   async _handleCallback(): Promise<boolean | void> {
@@ -396,11 +396,10 @@ export class Oauth2Scheme<
       })
 
       token =
-        (getResponseProp(response, this.options.token.property) as string) ||
-        token
+        (getProp(response.data, this.options.token.property) as string) || token
       refreshToken =
-        (getResponseProp(
-          response,
+        (getProp(
+          response.data,
           this.options.refreshToken.property
         ) as string) || refreshToken
     }
@@ -473,12 +472,9 @@ export class Oauth2Scheme<
   }
 
   protected updateTokens(response: HTTPResponse): void {
-    const token = getResponseProp(
-      response,
-      this.options.token.property
-    ) as string
-    const refreshToken = getResponseProp(
-      response,
+    const token = getProp(response.data, this.options.token.property) as string
+    const refreshToken = getProp(
+      response.data,
       this.options.refreshToken.property
     ) as string
 

--- a/src/schemes/refresh.ts
+++ b/src/schemes/refresh.ts
@@ -7,7 +7,7 @@ import type {
   RefreshableSchemeOptions
 } from '../types'
 import type { Auth } from '../core'
-import { cleanObj, getResponseProp } from '../utils'
+import { cleanObj, getProp } from '../utils'
 import {
   RefreshController,
   RefreshToken,
@@ -216,13 +216,10 @@ export class RefreshScheme<
     { isRefreshing = false, updateOnRefresh = true } = {}
   ): void {
     const token = this.options.token.required
-      ? (getResponseProp(response, this.options.token.property) as string)
+      ? (getProp(response.data, this.options.token.property) as string)
       : true
     const refreshToken = this.options.refreshToken.required
-      ? (getResponseProp(
-          response,
-          this.options.refreshToken.property
-        ) as string)
+      ? (getProp(response.data, this.options.refreshToken.property) as string)
       : true
 
     this.token.set(token)

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,4 @@
-import type { Route, HTTPResponse, RecursivePartial } from '../types'
+import type { Route, RecursivePartial } from '../types'
 
 export const isUnset = (o: unknown): boolean =>
   typeof o === 'undefined' || o === null
@@ -140,17 +140,6 @@ export function getProp(
   }
 
   return result
-}
-
-export function getResponseProp(
-  response: HTTPResponse,
-  prop: string | false
-): unknown {
-  if (typeof prop === 'string' && prop[0] === '.') {
-    return getProp(response, prop.substring(1))
-  } else {
-    return getProp(response.data, prop)
-  }
 }
 
 // Ie "Bearer " + token


### PR DESCRIPTION
The `getResponseProp` util is not useful anymore, since we merged #952