### PR TITLE
docs: Correct hyperlink to "Schemes and Strategies"

### DIFF
--- a/docs/content/en/glossary.md
+++ b/docs/content/en/glossary.md
@@ -15,7 +15,7 @@ Read more in [Schemes and Strategies](./guide/scheme) section.
 
 Strategy is a configured instance of Scheme.
 
-Read more in [Schemes and Strategies](./guide/schemes) section.
+Read more in [Schemes and Strategies](./guide/scheme) section.
 
 ## Provider
 


### PR DESCRIPTION
"Read more" link is pointing to the wrong url .