### PR TITLE
feat: use nuxt's base url setting

### DIFF
--- a/src/core/middleware.ts
+++ b/src/core/middleware.ts
@@ -28,7 +28,7 @@ export const authMiddleware: Middleware = async (ctx) => {
     'guest'
   )
   const insidePage = (page) =>
-    normalizePath(ctx.route.path) === normalizePath(page)
+    normalizePath(ctx.route.path, ctx) === normalizePath(page, ctx)
 
   if (ctx.$auth.$state.loggedIn) {
     // Perform scheme checks.

--- a/src/schemes/oauth2.ts
+++ b/src/schemes/oauth2.ts
@@ -148,10 +148,11 @@ export class Oauth2Scheme<
   }
 
   protected get redirectURI(): string {
-    return (
-      this.options.redirectUri ||
-      urlJoin(requrl(this.req), this.$auth.options.redirect.callback)
-    )
+    const basePath = this.$auth.ctx.base || ''
+    const path = normalizePath(
+      basePath + '/' + this.$auth.options.redirect.callback
+    ) // Don't pass in context since we want the base path
+    return this.options.redirectUri || urlJoin(requrl(this.req), path)
   }
 
   protected get logoutRedirectURI(): string {
@@ -334,8 +335,8 @@ export class Oauth2Scheme<
     // Handle callback only for specified route
     if (
       this.$auth.options.redirect &&
-      normalizePath(this.$auth.ctx.route.path) !==
-        normalizePath(this.$auth.options.redirect.callback)
+      normalizePath(this.$auth.ctx.route.path, this.$auth.ctx) !==
+        normalizePath(this.$auth.options.redirect.callback, this.$auth.ctx)
     ) {
       return
     }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+import type { Context } from '@nuxt/types'
 import type { Route, RecursivePartial } from '../types'
 
 export const isUnset = (o: unknown): boolean =>
@@ -5,11 +6,8 @@ export const isUnset = (o: unknown): boolean =>
 
 export const isSet = (o: unknown): boolean => !isUnset(o)
 
-export function isSameURL(a: string, b: string): boolean {
-  return (
-    a.split('?')[0].replace(/\/+$/, '') === b.split('?')[0].replace(/\/+$/, '')
-  )
-}
+export const isSameURL = (ctx: Context, a: string, b: string): boolean =>
+  normalizePath(a, ctx) === normalizePath(b, ctx)
 
 export function isRelativeURL(u: string): boolean {
   return (
@@ -79,14 +77,22 @@ export function getMatchedComponents(
   )
 }
 
-export function normalizePath(path = ''): string {
+export function normalizePath(path = '', ctx?: Context): string {
   // Remove query string
   let result = path.split('?')[0]
+
+  // Remove base path
+  if (ctx && ctx.base) {
+    result = result.replace(ctx.base, '/')
+  }
 
   // Remove redundant / from the end of path
   if (result.charAt(result.length - 1) === '/') {
     result = result.slice(0, -1)
   }
+
+  // Remove duplicate slashes
+  result = result.replace(/\/+/g, '/')
 
   return result
 }


### PR DESCRIPTION
Working off #489 

// cc @NickBolles

> There are 3 main changes here
> 
> 1. Update insidePage to take the context
> 2. Update isSameURL to take the context
> 3. Update normalizePath to take the context
> 4. For each of those if the context is passed in, replace the base path in the path we are checking with "/"
> 5. In oath2.js and middleware.js pass in context to these functions to allow the checks to succeed correctly. 
> 
> The only real issue with this (If i remember correctly) was that the callback path for OAUTH2 was not using the base path. But once we start using the base path it would also throw off the checking to see if this is the same route or not


Fixes #275, #879, 