### PR TITLE
fix: Module adds a second vue runtime to the bundle #1053

### DIFF
--- a/src/core/storage.ts
+++ b/src/core/storage.ts
@@ -1,5 +1,4 @@
 import type { Context } from '@nuxt/types'
-import Vue from 'vue'
 import cookie from 'cookie'
 import type { ModuleOptions } from '../options'
 import { isUnset, isSet, decodeValue, encodeValue, getProp } from '../utils'
@@ -106,7 +105,7 @@ export class Storage {
   _initState(): void {
     // Private state is suitable to keep information not being exposed to Vuex store
     // This helps prevent stealing token from SSR response HTML
-    Vue.set(this, '_state', {})
+    ;(this.ctx.app.store as any)._vm.$set(this, '_state', {})
 
     // Use vuex for local state's if possible
     this._useVuex = this.options.vuex && !!this.ctx.store
@@ -116,8 +115,12 @@ export class Storage {
         namespaced: true,
         state: () => this.options.initialState,
         mutations: {
-          SET(state, payload) {
-            Vue.set(state, payload.key, payload.value)
+          SET: (state, payload) => {
+            ;(this.ctx.app.store as any)._vm.$set(
+              state,
+              payload.key,
+              payload.value
+            )
           }
         }
       }
@@ -130,20 +133,20 @@ export class Storage {
 
       this.state = this.ctx.store.state[this.options.vuex.namespace]
     } else {
-      Vue.set(this, 'state', {})
+      ;(this.ctx.app.store as any)._vm.$set(this, 'state', {})
     }
   }
 
   setState<V extends unknown>(key: string, value: V): V {
     if (key[0] === '_') {
-      Vue.set(this._state, key, value)
+      ;(this.ctx.app.store as any)._vm.$set(this._state, key, value)
     } else if (this._useVuex) {
       this.ctx.store.commit(this.options.vuex.namespace + '/SET', {
         key,
         value
       })
     } else {
-      Vue.set(this.state, key, value)
+      ;(this.ctx.app.store as any)._vm.$set(this.state, key, value)
     }
 
     return value


### PR DESCRIPTION
This fixes the issue of adding a second vue runtime to the bundle, I tested it locally and the additional vue runtime disappeared.

I am not sure if the way I accessed $set is the best and especially unsure if my "typescript any hack" is appropriate. Let me know and I can change it