### PR TITLE
Logout Redirect

### DIFF
--- a/src/schemes/oauth2.ts
+++ b/src/schemes/oauth2.ts
@@ -306,7 +306,7 @@ export class Oauth2Scheme<
     if (this.options.endpoints.logout) {
       const opts = {
         client_id: this.options.clientId + '',
-        logout_uri: this.logoutRedirectURI
+        redirect_uri: this.logoutRedirectURI
       }
       const url = this.options.endpoints.logout + '?' + encodeQuery(opts)
       window.location.replace(url)


### PR DESCRIPTION
At the moment the redirect for logout in oauth2 is configured to use the parameter `logout_uri`.

According to my knowledge this value is not used by any oauth2 provider.

An industry standard, e.g. keycloak https://www.keycloak.org/docs/latest/securing_apps/#logout uses `redirect_uri` in the same way redirects are communicated in `Authorization Request` and `Access Token Request` are defined https://www.rfc-editor.org/info/rfc6749

This behaviour looks smart because it is compatible with the `openId connect session` draft. This specification accepts equal `redirect_uri` or `post_logout_redirect_uri`.
See https://openid.net/specs/openid-connect-session-1_0.html