### PR TITLE
Feat/extract token hook methods

### DIFF
--- a/src/schemes/local.ts
+++ b/src/schemes/local.ts
@@ -255,9 +255,13 @@ export class LocalScheme<
     }
   }
 
+  protected extractToken(response: HTTPResponse): string {
+    return getProp(response.data, this.options.token.property) as string
+  }
+
   protected updateTokens(response: HTTPResponse): void {
     const token = this.options.token.required
-      ? (getProp(response.data, this.options.token.property) as string)
+      ? this.extractToken(response)
       : true
 
     this.token.set(token)

--- a/src/schemes/refresh.ts
+++ b/src/schemes/refresh.ts
@@ -211,15 +211,23 @@ export class RefreshScheme<
     }
   }
 
+  protected extractToken(response: HTTPResponse): string {
+    return getProp(response.data, this.options.token.property) as string
+  }
+
+  protected extractRefreshToken(response: HTTPResponse): string {
+    return getProp(response.data, this.options.refreshToken.property) as string
+  }
+
   protected updateTokens(
     response: HTTPResponse,
     { isRefreshing = false, updateOnRefresh = true } = {}
   ): void {
     const token = this.options.token.required
-      ? (getProp(response.data, this.options.token.property) as string)
+      ? this.extractToken(response)
       : true
     const refreshToken = this.options.refreshToken.required
-      ? (getProp(response.data, this.options.refreshToken.property) as string)
+      ? this.extractRefreshToken(response)
       : true
 
     this.token.set(token)

--- a/src/schemes/refresh.ts
+++ b/src/schemes/refresh.ts
@@ -211,10 +211,6 @@ export class RefreshScheme<
     }
   }
 
-  protected extractToken(response: HTTPResponse): string {
-    return getProp(response.data, this.options.token.property) as string
-  }
-
   protected extractRefreshToken(response: HTTPResponse): string {
     return getProp(response.data, this.options.refreshToken.property) as string
   }


### PR DESCRIPTION
Currently the available login strategies expect tokens returned only in the body of JSON response.

There are servers (such as one in my case) that send the tokens in the headers rather than the body. 
In that case one can create a custom scheme that alters the behaviour of the base schema's _updateTokens_ method. However, overriding this method entirely is a bit too eager and may cause potential issues in future, at least in my opinion. 

I would like to propose a set of hook methods that would allow the developers write a login strategy that could, for example, look like this:

```js
export default class CustomAuthScheme extends RefreshScheme {
  extractToken(response) {
    return response.headers['x-auth-token']
  }

  extractRefreshToken(response) {
    return response.headers['x-auth-refresh-token']
  }
```

Before I created the PR I built the updated code base and verified it worked.

Any comments, ideas or arguments against would be appreciated.