### PR TITLE
docs: Document logic for storing the token in vuex state

### DIFF
--- a/docs/content/en/schemes/local.md
+++ b/docs/content/en/schemes/local.md
@@ -165,6 +165,14 @@ Here you configure the token options.
 
 `property` can be used to specify which field of the response JSON to be used for value. It can be `false` to directly use API response or being more complicated like `auth.token`.
 
+#### `prefix`
+
+- Default: `_token.`
+
+`prefix` sets the token prefix in the state. 
+
+**Note: if you are using vuex, the token will only appear in the `auth` state if the prefix does _not_ start with an underscore (`_`).**
+
 #### `required`
 
 - Default: `true`


### PR DESCRIPTION
This is as much an issue as it is a pull request. Currently your token will not appear in vuex with the default prefix (`_token.`). For me, this is unexpected and at the least should be documented, but may also be a bug.

The "offending" line is:

 https://github.com/nuxt-community/auth-module/blob/f6990742fb282663fe93d2dfc8091a62275a0ecc/src/core/storage.ts#L138 

With the default prefix, the token is not added to the vuex store. At the very least, this should be documented, but I argue that the default prefix should be changed (maybe to just `token`). What are the consequences of this?

Thanks for the lib! :)