### PR TITLE
chore(type):  `auth.plugins` option can mix use string[] and object[]

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -1,7 +1,7 @@
 import type { Strategy } from './types'
 
 export interface ModuleOptions {
-  plugins?: string[] | { src: string; ssr: boolean }[]
+  plugins?: Array<string | { src: string; ssr: boolean }>
   ignoreExceptions: boolean
   resetOnError: boolean | ((...args: unknown[]) => boolean)
   defaultStrategy: string


### PR DESCRIPTION
The `auth.plugins` option should be able to use both types of arrays. 
ref: https://auth.nuxtjs.org/recipes/extend