### PR TITLE
Fix link to tokens page

### DIFF
--- a/docs/content/en/api/auth.md
+++ b/docs/content/en/api/auth.md
@@ -162,4 +162,4 @@ export default function({ $auth }) {
 ## tokens
 
 **Token** and **Refresh Token** are available on `$auth.token` and `$auth.refreshToken`.
-Both have getters and setters and other helpers. Documented in [tokens.md](tokens.md)
+Both have getters and setters and other helpers. Documented in [tokens.md](./tokens)


### PR DESCRIPTION
The link to the tokens page was incorrect before and led to a 404 error on the documentation page. This commit fixes it.