### PR TITLE
Passing Vue.set function through plugin to avoid two vue runtimes in bundle

### DIFF
--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -39,7 +39,10 @@ export class Auth {
     this.options = options
     // Storage & State
     const initialState = { user: null, loggedIn: false }
-    const storage = new Storage(ctx, vueSet, { ...options, ...{ initialState } })
+    const storage = new Storage(ctx, vueSet, {
+      ...options,
+      ...{ initialState }
+    })
     this.$storage = storage
     this.$state = storage.state
   }

--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -34,13 +34,12 @@ export class Auth {
   private _stateWarnShown: boolean
   private _getStateWarnShown: boolean
 
-  constructor(ctx: Context, options: ModuleOptions) {
+  constructor(ctx: Context, vueSet: Function, options: ModuleOptions) {
     this.ctx = ctx
     this.options = options
-
     // Storage & State
     const initialState = { user: null, loggedIn: false }
-    const storage = new Storage(ctx, { ...options, ...{ initialState } })
+    const storage = new Storage(ctx, vueSet, { ...options, ...{ initialState } })
     this.$storage = storage
     this.$state = storage.state
   }

--- a/templates/plugin.js
+++ b/templates/plugin.js
@@ -1,5 +1,6 @@
 import Middleware from './middleware'
 import { Auth, authMiddleware, ExpiredAuthSessionError } from '~auth/runtime'
+import Vue from 'vue'
 
 // Active schemes
 <%= options.schemeImports.map(i => `import { ${i.name}${i.name !== i.as ? ' as ' + i.as : '' } } from '${i.from}'`).join('\n') %>
@@ -9,9 +10,8 @@ Middleware.auth = authMiddleware
 export default function (ctx, inject) {
   // Options
   const options = <%= JSON.stringify(options.options, null, 2) %>
-
   // Create a new Auth instance
-  const $auth = new Auth(ctx, options)
+  const $auth = new Auth(ctx, Vue.set, options)
 
   // Register strategies
   <%=

--- a/tsdoc-metadata.json
+++ b/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.12.1"
+      "packageVersion": "7.13.1"
     }
   ]
 }


### PR DESCRIPTION
Here: https://github.com/nuxt-community/auth-module/pull/1058
@pi0 said an acceptable hotfix would be to pass vue through the plugin.js in order to avoid 2 vue-runtimes in the bundle.

That's what I did and it seems to work

This would close: https://github.com/nuxt-community/auth-module/issues/1053