### PR TITLE
fix(core): fix baseURL for relative endpoints

### DIFF
--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -1,4 +1,5 @@
 import type { Context } from '@nuxt/types'
+import requrl from 'requrl'
 import type {
   HTTPRequest,
   HTTPResponse,
@@ -316,6 +317,11 @@ export class Auth {
       typeof defaults === 'object'
         ? Object.assign({}, defaults, endpoint)
         : endpoint
+
+    // Fix baseURL for relative endpoints
+    if (isRelativeURL(_endpoint.url)) {
+      _endpoint.baseURL = requrl(this.ctx.req)
+    }
 
     if (!this.ctx.app.$axios) {
       // eslint-disable-next-line no-console


### PR DESCRIPTION
Fix request for relative endpoints in server side, which was affecting all providers.

Due to this issue, refreshing token was not working on page reload.

Definitely fixes #1178