### PR TITLE
The key "clientId" should be "client_id"

### DIFF
--- a/docs/content/en/providers/auth0.md
+++ b/docs/content/en/providers/auth0.md
@@ -18,7 +18,7 @@ auth: {
   strategies: {
     auth0: {
       domain: 'domain.auth0.com',
-      clientId: '....',
+      client_id: '....',
       audience: 'https://my-api-domain.com/'
     }
   }
@@ -88,7 +88,7 @@ auth: {
   strategies: {
     auth0: {
       domain: 'domain.auth0.com',
-      clientId: '....',
+      client_id: '....',
       audience: 'https://my-api-domain.com/',
       scope: ['openid', 'profile', 'email', 'offline_access'],
       responseType: 'code',


### PR DESCRIPTION
The key "clientId" in the configuration should be "client_id" else its throwing client id not found.