### PR TITLE
docs(api): fix typo in options.md

### DIFF
--- a/docs/content/en/api/options.md
+++ b/docs/content/en/api/options.md
@@ -149,4 +149,4 @@ Vuex store namespace for keeping state.
 
 * Default: `scope`
 
-`user` object property used for scope checking (`hasScope`). Can be either an array or a object.
+`user` object property used for scope checking (`hasScope`). Can be either an array or an object.


### PR DESCRIPTION
Very minor edit on the documentation.