### PR TITLE
docs(api): fix access of token and refresh token instances

### DIFF
--- a/docs/content/en/api/auth.md
+++ b/docs/content/en/api/auth.md
@@ -161,5 +161,5 @@ export default function({ $auth }) {
 
 ## tokens
 
-**Token** and **Refresh Token** are available on `$auth.token` and `$auth.refreshToken`.
+**Token** and **Refresh Token** are available on `$auth.strategy.token.get()` and `$auth.strategy.refreshToken.get()`.
 Both have getters and setters and other helpers. Documented in [tokens.md](./tokens)

--- a/docs/content/en/api/auth.md
+++ b/docs/content/en/api/auth.md
@@ -161,5 +161,5 @@ export default function({ $auth }) {
 
 ## tokens
 
-**Token** and **Refresh Token** are available on `$auth.strategy.token.get()` and `$auth.strategy.refreshToken.get()`.
+**Token** and **Refresh Token** are available on `$auth.strategy.token` and `$auth.strategy.refreshToken`.
 Both have getters and setters and other helpers. Documented in [tokens.md](./tokens)


### PR DESCRIPTION
Before :
$auth.token and $auth.refreshToken

After: 
$auth.strategy.token.get()
$auth.strategy.refreshToken.get()