### PR TITLE
Router-redirect to home when storage is only vuex

### DIFF
--- a/src/schemes/oauth2.ts
+++ b/src/schemes/oauth2.ts
@@ -432,7 +432,7 @@ export class Oauth2Scheme<
     return redirectType
   }
 
-  callBackRedirectType () {
+  callBackRedirectType() {
     return !this.$auth.options.localStorage &&
       !this.$auth.options.cookie &&
       isSet(this.$auth.options.vuex) ? RedirectType.ROUTER_REDIRECT : RedirectType.BROWSER_REDIRECT

--- a/src/schemes/oauth2.ts
+++ b/src/schemes/oauth2.ts
@@ -433,9 +433,11 @@ export class Oauth2Scheme<
   }
 
   callBackRedirectType() {
-    return !this.$auth.options.localStorage &&
-      !this.$auth.options.cookie &&
-      isSet(this.$auth.options.vuex) ? RedirectType.ROUTER_REDIRECT : RedirectType.BROWSER_REDIRECT
+    if(!this.$auth.options.localStorage && !this.$auth.options.cookie &&
+      isSet(this.$auth.options.vuex)) {
+      return RedirectType.ROUTER_REDIRECT
+    }
+    return RedirectType.BROWSER_REDIRECT
   }
 
   async refreshTokens(): Promise<HTTPResponse | void> {

--- a/src/schemes/oauth2.ts
+++ b/src/schemes/oauth2.ts
@@ -18,7 +18,8 @@ import {
   parseQuery,
   removeTokenPrefix,
   urlJoin,
-  randomString
+  randomString,
+  isSet
 } from '../utils'
 import {
   RefreshController,
@@ -101,6 +102,11 @@ const DEFAULTS: SchemePartialOptions<Oauth2SchemeOptions> = {
   },
   responseType: 'token',
   codeChallengeMethod: 'implicit'
+}
+
+const enum RedirectType {
+  BROWSER_REDIRECT = 'browser-redirect',
+  ROUTER_REDIRECT = 'router-redirect'
 }
 
 export class Oauth2Scheme<
@@ -220,9 +226,9 @@ export class Oauth2Scheme<
     )
 
     // Handle callbacks on page load
-    const redirected = await this._handleCallback()
+    const redirectType = await this._handleCallback()
 
-    if (!redirected) {
+    if (redirectType === RedirectType.ROUTER_REDIRECT) {
       return this.$auth.fetchUserOnce()
     }
   }
@@ -331,7 +337,7 @@ export class Oauth2Scheme<
     this.$auth.setUser(getProp(response.data, this.options.user.property))
   }
 
-  async _handleCallback(): Promise<boolean | void> {
+  async _handleCallback(): Promise<RedirectType | void> {
     // Handle callback only for specified route
     if (
       this.$auth.options.redirect &&
@@ -417,10 +423,19 @@ export class Oauth2Scheme<
       this.refreshToken.set(refreshToken)
     }
 
-    // Redirect to home
-    this.$auth.redirect('home', true)
+    const redirectType = this.callBackRedirectType()
+    const noRouter = redirectType === RedirectType.BROWSER_REDIRECT
 
-    return true // True means a redirect happened
+    // Redirect to home
+    this.$auth.redirect('home', noRouter)
+
+    return redirectType
+  }
+
+  callBackRedirectType () {
+    return !this.$auth.options.localStorage &&
+      !this.$auth.options.cookie &&
+      isSet(this.$auth.options.vuex) ? RedirectType.ROUTER_REDIRECT : RedirectType.BROWSER_REDIRECT
   }
 
   async refreshTokens(): Promise<HTTPResponse | void> {

--- a/src/schemes/oauth2.ts
+++ b/src/schemes/oauth2.ts
@@ -433,8 +433,11 @@ export class Oauth2Scheme<
   }
 
   callBackRedirectType() {
-    if(!this.$auth.options.localStorage && !this.$auth.options.cookie &&
-      isSet(this.$auth.options.vuex)) {
+    if(
+      !this.$auth.options.localStorage &&
+      !this.$auth.options.cookie &&
+      isSet(this.$auth.options.vuex)
+    ) {
       return RedirectType.ROUTER_REDIRECT
     }
     return RedirectType.BROWSER_REDIRECT


### PR DESCRIPTION
I thought I would simply raise a PR and explain why I thought this change was relevant. Currently we have a customer who doesn't want any token data to be stored in either cookie or local storage but application state. Because the session information is saved with the authorization client and whenever the app tries to authenticate with a valid client-id the authorization client would respond back with code to query the token.

The auth-module say that we can set `localStorage` and `cookie` to `false`. But also it doesn't say we can set it to use vuex only. However, when I tried, the app kept on redirecting back and forth with auth client. After a lot of digging and debugging I found that the `_handleCallback` method calls the redirect method with `noRouter` option `true`. This makes no sense for vuex only session. Because the moment we access the full URL directly the vuex state is gone and the the authorize redirection happens again. So its imperative that we do and we can only do a router navigation. 