### PR TITLE
fix: Make oauth2 scheme respect watchLoggedIn configuration

### DIFF
--- a/src/schemes/oauth2.ts
+++ b/src/schemes/oauth2.ts
@@ -418,9 +418,10 @@ export class Oauth2Scheme<
     }
 
     // Redirect to home
-    this.$auth.redirect('home', true)
-
-    return true // True means a redirect happened
+    if (this.options.watchLoggedIn) {
+      this.$auth.redirect('home', true)
+      return true // True means a redirect happened
+    }
   }
 
   async refreshTokens(): Promise<HTTPResponse | void> {


### PR DESCRIPTION
At the moment it is not possible to disable the redirect to the home path for the default oauth2 scheme. 
As described in the [Options#watchLoggedIn](https://github.com/nuxt-community/auth-module/blob/3c73e64a4f03907fa9370427fe74978ec17965df/docs/content/en/api/options.md#watchloggedin) documentation, the `watchLoggedIn` property in the auth module configuration should disable this behaviour.
If this behaviour is expected to be modified by extending the default oauth2 scheme, this would require a complete "reimplementation" (copy) of the `_handleCallback` function.