### PR TITLE
Referencing the correct package name.

### DIFF
--- a/docs/content/en/recipes/extend.md
+++ b/docs/content/en/recipes/extend.md
@@ -10,7 +10,7 @@ If you have plugins that need to access `$auth`, you can use `auth.plugins` opti
 ```js{}[nuxt.config.js]
 {
   modules: [
-    '@nuxtjs/auth'
+    '@nuxtjs/auth-next'
   ],
   auth: {
      plugins: [ '~/plugins/auth.js' ]


### PR DESCRIPTION
If you follow this guide then it instructs you to install `@nextjs/auth-next` but in the extending the plugins recipe it referenced the package that is not from the install section leading to errors in the app.