### PR TITLE
fix: Make invalid password error appear properly in demo

### DIFF
--- a/demo/pages/login.vue
+++ b/demo/pages/login.vue
@@ -168,7 +168,8 @@ export default Vue.extend({
         .catch((err) => {
           // eslint-disable-next-line no-console
           console.error(err)
-          this.error = err.response?.data
+          const responseData = err.response?.data
+          this.error = responseData?.error ?? responseData
         })
     },
 


### PR DESCRIPTION
When you enter an invalid password in the demo, no error is shown. Nothing happens:

![before](https://user-images.githubusercontent.com/4397296/130612605-ec8a2acf-68e2-47cc-b412-50fe1033e11c.gif)

That's because the response body itself is not just the error object, rather it has the error object in its `error` property. So this change is to correctly pull the error out of the response body.

After the fix:

![after](https://user-images.githubusercontent.com/4397296/130613271-8f4a598e-ace3-41a8-8bee-a4095077bc00.gif)
