### PR TITLE
Fix typo

### DIFF
--- a/docs/content/en/guide/middleware.md
+++ b/docs/content/en/guide/middleware.md
@@ -24,7 +24,7 @@ router: {
 }
 ```
 
-In case of global usage, You can set `auth` option to `false` in a specific component and the middleware will ignore that route.
+In case of global usage, you can set `auth` option to `false` in a specific component and the middleware will ignore that route.
 
 ```js
 export default {


### PR DESCRIPTION
Fixed capitalization typo.

`...usage, You can...` -> `...usage, you can...`