### PR TITLE
docs: Add clarification to user options placement

### DIFF
--- a/docs/content/en/schemes/local.md
+++ b/docs/content/en/schemes/local.md
@@ -206,7 +206,7 @@ By default is set to 30 minutes.
 
 ### `user`
 
-Here you configure the user options.
+Here you configure the user options. Note that these options should be set in local.user and _not_ in the user endpoints options (local.endpoints.user). Refer to the example above for further clarification.
 
 #### `property`
 

--- a/docs/content/en/schemes/refresh.md
+++ b/docs/content/en/schemes/refresh.md
@@ -179,7 +179,7 @@ If enabled, Authorization header won't be cleared before refreshing.
 
 ### `user`
 
-Here you configure the user options.
+Here you configure the user options. Note that these options should be set in local.user and _not_ in the user endpoints options (local.endpoints.user). Refer to the example above for further clarification.
 
 #### `property`
 


### PR DESCRIPTION
In a previous version, I believe that propertyName could be placed in the user option within endpoints. This led to some confusion for me when switching to auth-next, so I've added some clarification.