### PR TITLE
fix(discord scheme): Add more default options

### DIFF
--- a/src/providers/discord.ts
+++ b/src/providers/discord.ts
@@ -18,7 +18,9 @@ export function discord(
       token: 'https://discord.com/api/oauth2/token',
       userInfo: 'https://discord.com/api/users/@me'
     },
-    scope: ['identify', 'email']
+    scope: ['identify', 'email'],
+    grantType: 'authorization_code',
+    codeChallengeMethod: 'S256'
   }
 
   assignDefaults(strategy, DEFAULTS)


### PR DESCRIPTION
I had issues while connecting with the default options of the discord scheme. First of all, i had "missing code chllenge method" so i added S256 as default options. I also added "authorization_code" for grantType in order to proccess the code returned by redirect uri.