### PR TITLE
Fixed 404ed links to Vuex

### DIFF
--- a/docs/content/en/guide/setup.md
+++ b/docs/content/en/guide/setup.md
@@ -53,7 +53,7 @@ Then, add `@nuxtjs/auth-next` to the `modules` section of `nuxt.config.js`:
 
 <alert type="warning">
 
-When adding `auth-module` to a new Nuxt project ensure you have [activated the Vuex store](https://nuxtjs.org/guide/vuex-store/#activate-the-store). More information on how to do that can be found on the [Nuxt Getting Started Guide](https://nuxtjs.org/guides/directory-structure/store).
+When adding `auth-module` to a new Nuxt project ensure you have [activated the Vuex store](https://nuxtjs.org/docs/directory-structure/store#activate-the-store). More information on how to do that can be found on the [Nuxt Getting Started Guide](https://nuxtjs.org/docs/directory-structure/store).
 
 </alert>
 


### PR DESCRIPTION
In the setup section there is a warning about Vuex. In it there are two links, both of which were returning 404s. Changed the paths, which appear to the correct location. 