### PR TITLE
Remove index.html suffix in normalizePath

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -92,6 +92,11 @@ export function normalizePath(path = '', ctx?: Context): string {
     result = result.replace(ctx.base, '/')
   }
 
+  // Remove index.html suffix
+  if (result.match(/index\.html?$/)) {
+    result = result.replace(/index\.html?$/, '')
+  }
+
   // Remove redundant / from the end of path
   if (result.charAt(result.length - 1) === '/') {
     result = result.slice(0, -1)


### PR DESCRIPTION
Fixes recognizing auth callback with a static deployment target deployed to a storage bucket.

Additionally this config is required (inspired by https://stackoverflow.com/q/65645740/1823988):

```
  router: {
    middleware: ['auth'],
    extendRoutes(routes) {
      routes.forEach(route => {
        const alias = route.path.length > 1 ? `${route.path}/index.html` : '/index.html';
        route.alias = alias;
      });
    },
  },
```

Related issues:
https://github.com/nuxt-community/auth-module/issues/299
https://github.com/nuxt-community/auth-module/issues/485