### PR TITLE
fix: fix wrong url in auth.md 'setUser' section

### DIFF
--- a/docs/content/en/api/auth.md
+++ b/docs/content/en/api/auth.md
@@ -75,7 +75,7 @@ this.$auth.login(/* .... */)
 
 Set user data and update `loggedIn` state.
 
-> **TIP:** This function can be used to set the user using the login response after a successfully login, when [autoFetchUser](../schemes/local.md#autofetchuser) is disabled.
+> **TIP:** This function can be used to set the user using the login response after a successfully login, when [`user.autoFetch`](../schemes/local.md#autofetch) is disabled.
 
 ```js
 this.$auth.setUser(user)


### PR DESCRIPTION
Currently, the `autoFetchUser` link is pointing to the wrong page, so I modified it.