### PR TITLE
fix: fix wrong url in auth.md `tokens` section

### DIFF
--- a/docs/content/en/api/auth.md
+++ b/docs/content/en/api/auth.md
@@ -162,4 +162,4 @@ export default function({ $auth }) {
 ## tokens
 
 **Token** and **Refresh Token** are available on `$auth.strategy.token` and `$auth.strategy.refreshToken`.
-Both have getters and setters and other helpers. Documented in [tokens.md](./tokens.md)
+Both have getters and setters and other helpers. Documented in [tokens.md](../tokens)


### PR DESCRIPTION
The link in the statement
> ... and other helpers. Documented in tokens.md 

didn't have the correct link, so I fixed it