### PR TITLE
Added missing secondary types on `ModuleOptions.redirect`

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -10,11 +10,11 @@ export interface ModuleOptions {
   fullPathRedirect: boolean
   scopeKey: string
   redirect: {
-    login: string
-    logout: string
-    callback: string
-    home: string
-  }
+    login: string | boolean
+    logout: string | boolean
+    callback: string | boolean
+    home: string | boolean
+  } | boolean
   vuex: {
     namespace: string
   }


### PR DESCRIPTION
this is regarding an issue: https://github.com/nuxt-community/auth-module/issues/1358 where working feature (disabling redirect), mentioned in documentation was not included in `src/options.ts` `ModuleOptions.redirect` type description