### PR TITLE
fix: Add config for siroc to prevent overwriting ./index.d.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     }
   },
   "main": "./dist/module.js",
+  "types": "./dist/index.d.ts",
   "typings": "./index.d.ts",
   "files": [
     "dist",


### PR DESCRIPTION
see: https://github.com/nuxt-community/auth-module/issues/1398

This will prevent siroc, in the build process, overwriting `index.d.ts` - I cannot see a way to prevent siroc generating types at all, which would be best as the `./dist/index.d.ts` is overwritten anyway by the `yarn build:types` command.

Please let me know if I'm wrong, but I hope this won't mean that by introducing the `types` property, when this package is used that it will not conflict with the `typings` property which is what we really want to be used.