### PR TITLE
fix: prevent error when local storage isn't available

### DIFF
--- a/src/core/storage.ts
+++ b/src/core/storage.ts
@@ -189,6 +189,7 @@ export class Storage {
       return this.removeLocalStorage(key)
     }
 
+    // evaluate localStorage first to avoid issues with loading in an iframe
     if (!this.options.localStorage || typeof localStorage === 'undefined') {
       return
     }
@@ -207,6 +208,7 @@ export class Storage {
   }
 
   getLocalStorage(key: string): unknown {
+    // evaluate localStorage first to avoid issues with loading in an iframe
     if (!this.options.localStorage || typeof localStorage === 'undefined') {
       return
     }
@@ -219,6 +221,7 @@ export class Storage {
   }
 
   removeLocalStorage(key: string): void {
+    // evaluate localStorage first to avoid issues with loading in an iframe
     if (!this.options.localStorage || typeof localStorage === 'undefined') {
       return
     }

--- a/src/core/storage.ts
+++ b/src/core/storage.ts
@@ -189,7 +189,7 @@ export class Storage {
       return this.removeLocalStorage(key)
     }
 
-    if (typeof localStorage === 'undefined' || !this.options.localStorage) {
+    if (!this.options.localStorage || typeof localStorage === 'undefined') {
       return
     }
 
@@ -207,7 +207,7 @@ export class Storage {
   }
 
   getLocalStorage(key: string): unknown {
-    if (typeof localStorage === 'undefined' || !this.options.localStorage) {
+    if (!this.options.localStorage || typeof localStorage === 'undefined') {
       return
     }
 
@@ -219,7 +219,7 @@ export class Storage {
   }
 
   removeLocalStorage(key: string): void {
-    if (typeof localStorage === 'undefined' || !this.options.localStorage) {
+    if (!this.options.localStorage || typeof localStorage === 'undefined') {
       return
     }
 


### PR DESCRIPTION
This allows you to completely disable localStorage while working in an iframe