### PR TITLE
fix(openIDConnect scheme): Check token expiration before id_token

### DIFF
--- a/src/schemes/openIDConnect.ts
+++ b/src/schemes/openIDConnect.ts
@@ -113,15 +113,15 @@ export class OpenIDConnectScheme<
       return response
     }
 
-    // Id token has expired. Force reset.
-    if (idTokenStatus.expired()) {
-      response.idTokenExpired = true
-      return response
-    }
-
     // Token has expired, Force reset.
     if (tokenStatus.expired()) {
       response.tokenExpired = true
+      return response
+    }
+    
+    // Id token has expired. Force reset.
+    if (idTokenStatus.expired()) {
+      response.idTokenExpired = true
       return response
     }
 


### PR DESCRIPTION
During an Axios call, the token is not automatically refreshed because it relies on the tokenExpired return of the scheme check function, which first checks id_token which often expires at the same time, and therefore does not detect any problems.
By checking first the token expiration before the id_token, the problem is solved

Related issue : 
https://github.com/nuxt-community/auth-module/issues/1370