### PR TITLE
feat: allow client-secret to be transported in authorization header

### DIFF
--- a/docs/content/en/schemes/oauth2.md
+++ b/docs/content/en/schemes/oauth2.md
@@ -66,6 +66,7 @@ auth: {
       redirectUri: undefined,
       logoutRedirectUri: undefined,
       clientId: 'SET_ME',
+      clientSecretTransport: 'body',
       scope: ['openid', 'profile', 'email'],
       state: 'UNIQUE_AND_NON_GUESSABLE',
       codeChallengeMethod: '',
@@ -172,6 +173,14 @@ Should be an absolute path to the welcome screen
 ### `clientId`
 
 **REQUIRED** - oauth2 client id.
+
+### `clientSecretTransport`
+
+- Default: `body`
+
+If set to `body` the `client-secret` is transported within the payload.
+
+If set to `authorization_header` the `client-secret` is only part of the authorization header (Base64 client-id:client-secret). It is not part of the payload anymore.
 
 ### `scope`
 

--- a/src/schemes/oauth2.ts
+++ b/src/schemes/oauth2.ts
@@ -55,6 +55,7 @@ export interface Oauth2SchemeOptions
   redirectUri: string
   logoutRedirectUri: string
   clientId: string | number
+  clientSecretTransport: 'body' | 'authorization_header'
   scope: string | string[]
   state: string
   codeChallengeMethod: 'implicit' | 'S256' | 'plain'
@@ -69,6 +70,7 @@ const DEFAULTS: SchemePartialOptions<Oauth2SchemeOptions> = {
   redirectUri: null,
   logoutRedirectUri: null,
   clientId: null,
+  clientSecretTransport: 'body',
   audience: null,
   grantType: null,
   responseMode: null,

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -88,6 +88,15 @@ export function addAuthorize<
           'Content-Type': 'application/json'
         }
 
+        if (strategy.clientSecretTransport === 'authorization_header') {
+          // @ts-ignore
+          headers.Authorization =
+            'Basic ' +
+            Buffer.from(clientID + ':' + clientSecret).toString('base64')
+          // client_secret is transported in auth header
+          delete data.client_secret
+        }
+
         if (useForms) {
           data = qs.stringify(data)
           headers['Content-Type'] = 'application/x-www-form-urlencoded'


### PR DESCRIPTION
Add new property `clientSecretTransport` with options `body` and `authorization-header` to have 2 options for transporting the `client-secret`

If set to `body` the `client-secret` is transported within the payload.

If set to `authorization_header` the `client-secret` is only part of the authorization header (Base64 client-id:client-secret). It is not part of the payload anymore.