### PR TITLE
fix(openIDConnect scheme): Check token expiration before id_token

### DIFF
--- a/src/schemes/openIDConnect.ts
+++ b/src/schemes/openIDConnect.ts
@@ -122,9 +122,10 @@ export class OpenIDConnectScheme<
     /**
     Id token has expired. Force reset.
 
-    This ordering is required, because it is the access_token is sent in the
-    Authorization header when making an axios request. If the access_token
-    is expired, we need to refresh that token before continuing.
+    idToken needs to be set after token because it is the access_token
+    is sent in the Authorization header when making an axios request. If
+    the access_token is expired, we need to refresh that token before
+    continuing.
 
     Checking whether the id_token has expired doesn't guarantee a successful
     call to the (a) back end and typically the id_token has a different

--- a/src/schemes/openIDConnect.ts
+++ b/src/schemes/openIDConnect.ts
@@ -113,15 +113,15 @@ export class OpenIDConnectScheme<
       return response
     }
 
-    // Id token has expired. Force reset.
-    if (idTokenStatus.expired()) {
-      response.idTokenExpired = true
-      return response
-    }
-
     // Token has expired, Force reset.
     if (tokenStatus.expired()) {
       response.tokenExpired = true
+      return response
+    }
+    
+    // Id token has expired. Force reset.
+    if (idTokenStatus.expired()) {
+      response.idTokenExpired = true
       return response
     }
 

--- a/src/schemes/openIDConnect.ts
+++ b/src/schemes/openIDConnect.ts
@@ -122,7 +122,7 @@ export class OpenIDConnectScheme<
     /**
     Id token has expired. Force reset.
 
-    idToken needs to be set after token because it is the access_token
+    idToken needs to be set after token because the access_token
     is sent in the Authorization header when making an axios request. If
     the access_token is expired, we need to refresh that token before
     continuing.

--- a/src/schemes/openIDConnect.ts
+++ b/src/schemes/openIDConnect.ts
@@ -119,6 +119,7 @@ export class OpenIDConnectScheme<
       return response
     }
 
+
     /**
     Id token has expired. Force reset.
 

--- a/src/schemes/openIDConnect.ts
+++ b/src/schemes/openIDConnect.ts
@@ -118,7 +118,7 @@ export class OpenIDConnectScheme<
       response.tokenExpired = true
       return response
     }
-    
+
     // Id token has expired. Force reset.
     if (idTokenStatus.expired()) {
       response.idTokenExpired = true

--- a/src/schemes/openIDConnect.ts
+++ b/src/schemes/openIDConnect.ts
@@ -119,7 +119,18 @@ export class OpenIDConnectScheme<
       return response
     }
 
-    // Id token has expired. Force reset.
+    /**
+    Id token has expired. Force reset.
+
+    This ordering is required, because it is the access_token is sent in the
+    Authorization header when making an axios request. If the access_token
+    is expired, we need to refresh that token before continuing.
+
+    Checking whether the id_token has expired doesn't guarantee a successful
+    call to the (a) back end and typically the id_token has a different
+    (shorter) expiry schedule to the access_token.
+    */
+
     if (idTokenStatus.expired()) {
       response.idTokenExpired = true
       return response

--- a/src/schemes/openIDConnect.ts
+++ b/src/schemes/openIDConnect.ts
@@ -119,7 +119,6 @@ export class OpenIDConnectScheme<
       return response
     }
 
-
     /**
     Id token has expired. Force reset.
 


### PR DESCRIPTION
(Creating this pull request as it appears that it's stalled awaiting a PR into a another fork, rather than the dev branch)

Incorporates both changes from dygeenen and shollingsworth for this PR https://github.com/nuxt-community/auth-module/pull/1417

(thanks both)

This ordering is required, because it is the `access_token` is sent in the Authorization header when making an axios request.  If the `access_token` is expired, we need to refresh that token before continuing.

Checking whether the `id_token` has expired doesn't guarantee a successful call to the (a) back end and typically the `id_token` has a different (shorter) expiry schedule to the `access_token`.