### PR TITLE
docs: update laravel sanctum docs URL

### DIFF
--- a/docs/content/en/providers/laravel-sanctum.md
+++ b/docs/content/en/providers/laravel-sanctum.md
@@ -7,7 +7,7 @@ category: Providers
 
 [Source Code](https://github.com/nuxt-community/auth-module/blob/dev/src/providers/laravel-sanctum.ts)
 
-Laravel Sanctum provides a featherweight authentication system for SPAs (single page applications), mobile applications, and simple, token based APIs. Sanctum allows each user of your application to generate multiple API tokens for their account. These tokens may be granted abilities / scopes which specify which actions the tokens are allowed to perform. ([Read More](https://laravel.com/docs/9.x/sanctum))
+Laravel Sanctum provides a featherweight authentication system for SPAs (single page applications), mobile applications, and simple, token based APIs. Sanctum allows each user of your application to generate multiple API tokens for their account. These tokens may be granted abilities / scopes which specify which actions the tokens are allowed to perform. ([Read More](https://laravel.com/docs/sanctum))
 
 ## Usage
 

--- a/docs/content/en/providers/laravel-sanctum.md
+++ b/docs/content/en/providers/laravel-sanctum.md
@@ -7,7 +7,7 @@ category: Providers
 
 [Source Code](https://github.com/nuxt-community/auth-module/blob/dev/src/providers/laravel-sanctum.ts)
 
-Laravel Sanctum provides a featherweight authentication system for SPAs (single page applications), mobile applications, and simple, token based APIs. Sanctum allows each user of your application to generate multiple API tokens for their account. These tokens may be granted abilities / scopes which specify which actions the tokens are allowed to perform. ([Read More](https://laravel.com/docs/8.x/sanctum))
+Laravel Sanctum provides a featherweight authentication system for SPAs (single page applications), mobile applications, and simple, token based APIs. Sanctum allows each user of your application to generate multiple API tokens for their account. These tokens may be granted abilities / scopes which specify which actions the tokens are allowed to perform. ([Read More](https://laravel.com/docs/9.x/sanctum))
 
 ## Usage
 


### PR DESCRIPTION
Update `Laravel sanctum` docs URL to redirect to the latest version of `Laravel` currently (`9.x`), so we don't need to specify the version on every upgrade of the Framework anymore this will allow us to always redirect the user to the latest version.