### PR TITLE
fix: prevent error when local storage is not available

### DIFF
--- a/lib/core/storage.js
+++ b/lib/core/storage.js
@@ -6,6 +6,7 @@ export default class Storage {
   constructor (ctx, options) {
     this.ctx = ctx
     this.options = options
+    this.isLocalStorageAvailable = undefined
 
     this._initState()
   }
@@ -150,7 +151,7 @@ export default class Storage {
       return this.removeLocalStorage(key)
     }
 
-    if (typeof localStorage === 'undefined' || !this.options.localStorage) {
+    if (!this.localStorageEnabled() || !this.options.localStorage) {
       return
     }
 
@@ -168,7 +169,7 @@ export default class Storage {
   }
 
   getLocalStorage (key) {
-    if (typeof localStorage === 'undefined' || !this.options.localStorage) {
+    if (!this.localStorageEnabled() || !this.options.localStorage) {
       return
     }
 
@@ -180,7 +181,7 @@ export default class Storage {
   }
 
   removeLocalStorage (key) {
-    if (typeof localStorage === 'undefined' || !this.options.localStorage) {
+    if (!this.localStorageEnabled() || !this.options.localStorage) {
       return
     }
 
@@ -248,5 +249,37 @@ export default class Storage {
 
   removeCookie (key, options) {
     this.setCookie(key, undefined, options)
+  }
+
+  localStorageEnabled() {
+    if (process.server) {
+      this.isLocalStorageAvailable = false
+    }
+
+    if (this.isLocalStorageAvailable !== undefined) {
+      return this.isLocalStorageAvailable
+    }
+
+    // There's no great way to check if localStorage is enabled; most solutions
+    // error out. So have to use this hacky approach :\
+    // https://stackoverflow.com/questions/16427636/check-if-localstorage-is-available
+    const test = 'test'
+
+    try {
+      localStorage.setItem(test, test)
+      localStorage.removeItem(test)
+
+      this.isLocalStorageAvailable = true
+    } catch (e) {
+      if (this.options.localStorage) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          "[AUTH] Local storage is enabled in config, but browser doesn't support it"
+        )
+      }
+      this.isLocalStorageAvailable = false
+    } finally {
+      return this.isLocalStorageAvailable
+    }
   }
 }


### PR DESCRIPTION
There is a known issue with using the module in a browser with no `localStorage` available that has been fixed in the auth-v5, but it's still broken in the v4 - this PR only replicates the fix with a small improvement to avoid warnings in the server where `localStorage` will never be available.

[V5 reference fix](https://github.com/nuxt-community/auth-module/pull/1415)
[Original issue](https://github.com/nuxt-community/auth-module/pull/1405)