### PR TITLE
feat: Use oAuth expires_in parameter for accessToken

### DIFF
--- a/src/inc/token.ts
+++ b/src/inc/token.ts
@@ -20,11 +20,11 @@ export class Token {
     return this.$storage.getUniversal(_key) as string | boolean
   }
 
-  set(tokenValue: string | boolean): string | boolean {
+  set(tokenValue: string | boolean, expiresIn: number | boolean = false): string | boolean {
     const token = addTokenPrefix(tokenValue, this.scheme.options.token.type)
 
     this._setToken(token)
-    this._updateExpiration(token)
+    this._updateExpiration(token, expiresIn)
 
     if (typeof token === 'string') {
       this.scheme.requestHandler.setHeader(token)
@@ -72,10 +72,11 @@ export class Token {
     return this.$storage.syncUniversal(_key) as number | false
   }
 
-  private _updateExpiration(token: string | boolean): number | false | void {
+  private _updateExpiration(token: string | boolean , expiresIn: number | boolean): number | false | void {
     let tokenExpiration
     const _tokenIssuedAtMillis = Date.now()
-    const _tokenTTLMillis = Number(this.scheme.options.token.maxAge) * 1000
+    const _maxAge = expiresIn ? expiresIn : this.scheme.options.token.maxAge
+    const _tokenTTLMillis = Number(_maxAge) * 1000
     const _tokenExpiresAtMillis = _tokenTTLMillis
       ? _tokenIssuedAtMillis + _tokenTTLMillis
       : 0

--- a/src/schemes/oauth2.ts
+++ b/src/schemes/oauth2.ts
@@ -355,6 +355,9 @@ export class Oauth2Scheme<
     const parsedQuery = Object.assign({}, this.$auth.ctx.route.query, hash)
     // accessToken/idToken
     let token: string = parsedQuery[this.options.token.property] as string
+    // recommended accessToken lifetime
+    let tokenExpiresIn: number | boolean = false
+
     // refresh token
     let refreshToken: string
 
@@ -404,6 +407,8 @@ export class Oauth2Scheme<
 
       token =
         (getProp(response.data, this.options.token.property) as string) || token
+      tokenExpiresIn = 
+        (getProp(response.data, 'expires_in') as number) || tokenExpiresIn
       refreshToken =
         (getProp(
           response.data,
@@ -416,7 +421,7 @@ export class Oauth2Scheme<
     }
 
     // Set token
-    this.token.set(token)
+    this.token.set(token, tokenExpiresIn)
 
     // Store refresh token
     if (refreshToken && refreshToken.length) {

--- a/src/schemes/openIDConnect.ts
+++ b/src/schemes/openIDConnect.ts
@@ -230,6 +230,8 @@ export class OpenIDConnectScheme<
 
     // accessToken/idToken
     let token: string = parsedQuery[this.options.token.property] as string
+    // recommended accessToken lifetime
+    let tokenExpiresIn: number | boolean = false
 
     // refresh token
     let refreshToken: string
@@ -282,6 +284,8 @@ export class OpenIDConnectScheme<
 
       token =
         (getProp(response.data, this.options.token.property) as string) || token
+      tokenExpiresIn = 
+        (getProp(response.data, 'expires_in') as number) || tokenExpiresIn
       refreshToken =
         (getProp(
           response.data,
@@ -298,7 +302,7 @@ export class OpenIDConnectScheme<
     }
 
     // Set token
-    this.token.set(token)
+    this.token.set(token, tokenExpiresIn)
 
     // Store refresh token
     if (refreshToken && refreshToken.length) {


### PR DESCRIPTION
The [oAuth 2.0 RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749) recommends to use the parameter `expires_in` to set a token expiration time. When given this parameter should be used instead of the maxAge value for the token.

My Solutionen does not provide a way to overwrite the value, if this parameter is returned with the accessToken by an IDP. Maybe an improvement is required for this problem? If yes, I would be glad for any suggestion how to do so.


I explicit do not add this parameter to the `id-token.ts`, as an ID-Token **must** have the `exp` parameter, which will always overwrite the value. [Required by openid](https://openid.net/specs/openid-connect-core-1_0.html#IDToken)

Not sure if using the boolean `false` value is a pretty way to handle the absence of `expires_in`

---

Thanks for your review / feedback
