### PR TITLE
Make the `tsconfig.json` valid as JSON

### DIFF
--- a/docs/content/en/guide/setup.md
+++ b/docs/content/en/guide/setup.md
@@ -69,11 +69,11 @@ Add `@nuxtjs/auth-next` to the `compilerOptions.types` section of your project's
 
 ```json{}[tsconfig.json]
 {
-  compilerOptions: {
+  "compilerOptions": {
     "types": [
-      "@nuxtjs/auth-next",
+      "@nuxtjs/auth-next"
     ]
-  },
+  }
 }
 ```
 


### PR DESCRIPTION
Hello maintainer-san, 👋🏽 

It is just a trivial thing, but I would like to report that it won't confuse users if the JSON is in the correct format.

Thanks,