### PR TITLE
Add tests for validating token expiry works

### DIFF
--- a/demo/api/auth.js
+++ b/demo/api/auth.js
@@ -28,27 +28,26 @@ const refreshTokens = {}
 
 // [POST] /login
 app.post('/login', (req, res) => {
-  const { username, password } = req.body
+  const { username, password, expiryTime } = req.body
   const valid = username.length && password === '123'
   const expiresIn = 15
   const refreshToken =
     Math.floor(Math.random() * (1000000000000000 - 1 + 1)) + 1
 
+  const payload = {
+    username,
+    picture: 'https://github.com/nuxt.png',
+    name: 'User ' + username,
+    scope: ['test', 'user']
+  }
   if (!valid) {
     throw new Error('Invalid username or password')
   }
 
   const accessToken = jsonwebtoken.sign(
-    {
-      username,
-      picture: 'https://github.com/nuxt.png',
-      name: 'User ' + username,
-      scope: ['test', 'user']
-    },
+    expiryTime ? { ...payload, exp: expiryTime } : payload,
     'dummy',
-    {
-      expiresIn
-    }
+    expiryTime ? {} : { expiresIn }
   )
 
   refreshTokens[refreshToken] = {

--- a/test/expiry.test.ts
+++ b/test/expiry.test.ts
@@ -1,0 +1,38 @@
+import { setupTest, createPage } from '@nuxt/test-utils'
+import jwtDecode from 'jwt-decode'
+import { LocalScheme } from '../src'
+describe('expiry', () => {
+  setupTest({
+    browser: true
+  })
+
+  test('token expiry is decoded correctly', async () => {
+    const page = await createPage('/')
+    await page.waitForFunction('!!window.$nuxt')
+
+    const { expectedExpiryTime, evaluatedExpiryTime, loginResponse } =
+      await page.evaluate(async () => {
+        const expiryTime = Math.floor(Date.now() / 1000) - 1000
+        window.$nuxt.$auth.strategies.local.options.user.autoFetch = false
+        const loginResponse = await window.$nuxt.$auth.loginWith('local', {
+          data: { username: 'test_username', password: '123', expiryTime }
+        })
+
+        const strategy =
+          window.$nuxt.$auth.getStrategy() as unknown as LocalScheme
+
+        return {
+          loginResponse,
+          expectedExpiryTime: expiryTime,
+          // @ts-ignore
+          evaluatedExpiryTime: strategy.token._getExpiration()
+        }
+      })
+
+    const token = jwtDecode<{ exp: number }>(
+      loginResponse.data.token.accessToken
+    )
+    expect(token.exp).toEqual(expectedExpiryTime)
+    expect(evaluatedExpiryTime).toEqual(expectedExpiryTime * 1000)
+  })
+})


### PR DESCRIPTION
While investigating an auth issue in our application, I noticed a potential bug with the token expiry decoding. Since the token is stored prefixed by the token type, the `decodeJwt` method attempts to decode this with the prefix. This should lead to an error, however the `jwt-decode` library does not [actually check for the structure of the token](https://github.com/auth0/jwt-decode/blob/bf94804a7cff88904c0b504dcfbfc481fc68500c/lib/index.js#L20). 

I believe this should be fixed anyway, as the potential for issue is high, however it is not currently broken. That is why this PR is only a test to ensure that the expiration works as intended.

As a sidenote, I am disappointed with how difficult this library is to test, considering the importance of auth. The side effects littered throughout the modules ensure that actual validation of the library is made cumbersome.