### PR TITLE
Ensure all token refreshes use the Controller

### DIFF
--- a/src/inc/request-handler.ts
+++ b/src/inc/request-handler.ts
@@ -58,8 +58,8 @@ export class RequestHandler {
         }
 
         // Refresh token is available. Attempt refresh.
-        isValid = await (this.scheme as RefreshableScheme)
-          .refreshTokens()
+        isValid = await (this.scheme as RefreshableScheme).refreshController
+          .handleRefresh()
           .then(() => true)
           .catch(() => {
             // Tokens couldn't be refreshed. Force reset.


### PR DESCRIPTION
The issue was found when an expired token was used in a client-side navigation to a page with multiple `axios` requests. Each request would send out a refresh request first. In our case, if would cause multiple new tokens to be created while only the last would be allowed. This then could cause a race condition which would log the user out.

The fix implemented is to simply use the pre-existing `RefreshController` to ensure that only one refresh request is sent.