### PR TITLE
Fix broken links

### DIFF
--- a/docs/content/en/api-index.md
+++ b/docs/content/en/api-index.md
@@ -5,6 +5,6 @@ position: 50
 category: API
 ---
 
-- [options](./api/options)
-- [auth](./api/auth)
-- [storage](./api/storage)
+- [options](../api/options)
+- [auth](../api/auth)
+- [storage](../api/storage)


### PR DESCRIPTION
Links point to:

https://auth.nuxtjs.org/api-index/api/options

instead of:

https://auth.nuxtjs.org/api/options