### PR TITLE
fix(openIDConnect scheme): Fixing typo in expected configuration response key

### DIFF
--- a/src/inc/configuration-document.ts
+++ b/src/inc/configuration-document.ts
@@ -73,7 +73,7 @@ export class ConfigurationDocument {
 
   validate() {
     const mapping = {
-      responseType: 'response_type_supported',
+      responseType: 'response_types_supported',
       scope: 'scopes_supported',
       grantType: 'grant_types_supported',
       acrValues: 'acr_values_supported'


### PR DESCRIPTION
`response_type_supported` should be `response_types_supported` (plural) as per openid spec 1.0


https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationResponse