### PR TITLE
consistent examples for time values

### DIFF
--- a/docs/content/en/schemes/oauth2.md
+++ b/docs/content/en/schemes/oauth2.md
@@ -54,7 +54,7 @@ auth: {
       token: {
         property: 'access_token',
         type: 'Bearer',
-        maxAge: 1800
+        maxAge: 60 * 30
       },
       refreshToken: {
         property: 'refresh_token',
@@ -119,7 +119,7 @@ It will be used in `Authorization` header of axios requests.
 
 #### `maxAge`
 
-- Default: `1800`
+- Default: `60 * 30`
 
 Here you set the expiration time of the token, in **seconds**.
 This time will be used if for some reason we couldn't decode the token to get the expiration date.

--- a/docs/content/en/schemes/openIDConnect.md
+++ b/docs/content/en/schemes/openIDConnect.md
@@ -108,7 +108,7 @@ It will be used in `Authorization` header of axios requests.
 
 #### `maxAge`
 
-- Default: `1800`
+- Default: `60 * 30`
 
 Here you set the expiration time of the token, in **seconds**.
 This time will be used if for some reason we couldn't decode the token to get the expiration date.
@@ -129,7 +129,7 @@ The OpenIDConnect scheme will save both the access and ID token. This because to
 
 #### `maxAge`
 
-- Default: `1800`
+- Default: `60 * 30`
 
 Here you set the expiration time of the ID token, in **seconds**.
 This time will be used if for some reason we couldn't decode the ID token to get the expiration date.


### PR DESCRIPTION
In the other example we are using a format like this: 
![image](https://user-images.githubusercontent.com/5755214/213893899-6b3a341d-f848-444e-8410-3ced2a56d8d3.png)


So I thought it looks better if they are consistent