### PR TITLE
fix(core): fix missing query parameters when router.base is a subdirectory.

### DIFF
--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -443,7 +443,7 @@ export class Auth {
     if (process.client) {
       if (noRouter) {
         if (isRelativeURL(to) && !to.includes(this.ctx.base)) {
-          to = normalizePath('/' + this.ctx.base + '/' + to) // Don't pass in context to preserve base url
+          to = normalizePath('/' + this.ctx.base) + to // Don't pass in context to preserve base url
         }
         window.location.replace(to)
       } else {


### PR DESCRIPTION
Hello.
I have fixed a problem with query parameters being lost even with `fullPathRedirect` enabled.
The problem occurs when a subdirectory is specified in `router.base` in `nuxt.config.js` as follows.
```javascript
export default {
  router: {
    base: '/app/'
  },
  auth: {
    fullPathRedirect: true
  }
}
```
This problem is caused by `normalizePath` being executed on the URL retrieved by `this.$storage.getUniversal('redirect')`.
To avoid this problem, I have changed where `normalizePath` is executed.

For example, if you intended to forward to `https://localhost/app/foo?bar=123` after login
`/foo?bar=123` will be replaced by `normalizePath`, resulting in a transfer to `https://localhost/app/foo`.
This problem has been resolved in this commit.

Issue is here https://github.com/nuxt-community/auth-module/issues/1828

Thanks for the confirmation.