### PR TITLE
fix(schemes): OAuth2 URL may already contain query params

### DIFF
--- a/src/schemes/oauth2.ts
+++ b/src/schemes/oauth2.ts
@@ -303,7 +303,14 @@ export class Oauth2Scheme<
 
     this.$auth.$storage.setUniversal(this.name + '.state', opts.state)
 
-    const url = this.options.endpoints.authorization + '?' + encodeQuery(opts)
+    let url = this.options.endpoints.authorization
+    // Authorization endpoint URL may already contain query params
+    if (url.split('/').splice(-1)[0].indexOf('?') === -1 ) {
+      url = url + '?' + encodeQuery(opts)
+    }
+    else {
+      url = url + '&' + encodeQuery(opts)
+    }
 
     window.location.replace(url)
   }
@@ -314,7 +321,16 @@ export class Oauth2Scheme<
         client_id: this.options.clientId + '',
         logout_uri: this.logoutRedirectURI
       }
-      const url = this.options.endpoints.logout + '?' + encodeQuery(opts)
+
+      let url = this.options.endpoints.logout
+      // Logout endpoint URL may already contain query params
+      if (url.split('/').splice(-1)[0].indexOf('?') === -1 ) {
+        url = url + '?' + encodeQuery(opts)
+      }
+      else {
+        url = url + '&' + encodeQuery(opts)
+      }
+
       window.location.replace(url)
     }
     return this.$auth.reset()

--- a/src/schemes/openIDConnect.ts
+++ b/src/schemes/openIDConnect.ts
@@ -182,7 +182,16 @@ export class OpenIDConnectScheme<
         id_token_hint: this.idToken.get(),
         post_logout_redirect_uri: this.logoutRedirectURI
       }
-      const url = this.options.endpoints.logout + '?' + encodeQuery(opts)
+
+      let url = this.options.endpoints.logout
+      // Logout endpoint URL may already contain query params
+      if (url.split('/').splice(-1)[0].indexOf('?') === -1 ) {
+        url = url + '?' + encodeQuery(opts)
+      }
+      else {
+        url = url + '&' + encodeQuery(opts)
+      }
+
       window.location.replace(url)
     }
     return this.$auth.reset()


### PR DESCRIPTION
Hello.
This is my first Pull Request, so sorry if there are some problem.

I have fixed a problem which occurs when OAuth2 authorization endpoint URL contains '?'.

If OAuth2 authorization endpoint URL contains '?' (=already has query params), this module will join options generated by this module to given URL with '&' ,not '?'.

Issue is here #1831 

Thanks for the confirmation.