### PR TITLE
docs: fixed broken link

### DIFF
--- a/docs/content/en/index.md
+++ b/docs/content/en/index.md
@@ -22,7 +22,7 @@ Meanwhile, we recommend:
 
 - [Sidebase Nuxt Auth](https://github.com/sidebase/nuxt-auth) based on next-auth
 - [AuthJs Nuxt](https://github.com/Hebilicious/authjs-nuxt) based on Auth.js
-- Implement your own auth using [Lucia](https://lucia-auth.com/guidebook/sign-in-with-username-and-password/nuxt/) or [Nuxt Auth Template](https://github.com/nuxt/examples/tree/main/auth/local)
+- Implement your own auth using [Lucia](https://lucia-auth.com/guidebook/sign-in-with-username-and-password/nuxt/) or [Nuxt Auth Template](https://github.com/nuxt/examples/tree/main/examples/auth/local)
 
 ## Getting Started
 


### PR DESCRIPTION
Fixed broken "Nuxt Auth Template" link which now points to correct "Nuxt with Local Auth" example on GitHub.