### PR TITLE
fix(schemes): OAuth urls are not formatted properly if they have a query parameter

### DIFF
--- a/src/schemes/oauth2.ts
+++ b/src/schemes/oauth2.ts
@@ -303,8 +303,8 @@ export class Oauth2Scheme<
 
     this.$auth.$storage.setUniversal(this.name + '.state', opts.state)
 
-    const url = this.options.endpoints.authorization + '?' + encodeQuery(opts)
-
+    const urlConcat = this.options.endpoints.authorization.includes('?') ? '&' : '?';
+    const url = this.options.endpoints.authorization + urlConcat + encodeQuery(opts)
     window.location.replace(url)
   }
 
@@ -314,7 +314,8 @@ export class Oauth2Scheme<
         client_id: this.options.clientId + '',
         logout_uri: this.logoutRedirectURI
       }
-      const url = this.options.endpoints.logout + '?' + encodeQuery(opts)
+      const urlConcat = this.options.endpoints.logout.includes('?') ? '&' : '?';
+      const url = this.options.endpoints.logout + urlConcat + encodeQuery(opts)
       window.location.replace(url)
     }
     return this.$auth.reset()


### PR DESCRIPTION
Hello!

We are using an AzureB2C for our authentication and they provide their URLS with a query parameters. This breaks the sections I fixed with the way the OAuth query parameters are appended to the url.

Here's the OpenIDC Configuration if you're curious: https://alvb2ctest.b2clogin.com/ALVB2CTEST.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1A_ALV_ASCP_SIGNUP_SIGNIN

I only provide a short way to do it, but if there's a recommended way to fix it, I can work on it that way.