### PR TITLE
#doc Fix the link to Nuxt Auth Template in the documenation homepage

### DIFF
--- a/docs/content/en/index.md
+++ b/docs/content/en/index.md
@@ -23,7 +23,7 @@ Meanwhile, we recommend:
 - [Nuxt Auth Utils](https://github.com/atinux/nuxt-auth-utils)
 - [Sidebase Nuxt Auth](https://github.com/sidebase/nuxt-auth) based on next-auth
 - [AuthJs Nuxt](https://github.com/Hebilicious/authjs-nuxt) based on Auth.js
-- Implement your own auth using [Lucia](https://lucia-auth.com/guidebook/sign-in-with-username-and-password/nuxt/) or [Nuxt Auth Template](https://github.com/nuxt/examples/tree/main/auth/local)
+- Implement your own auth using [Lucia](https://lucia-auth.com/guidebook/sign-in-with-username-and-password/nuxt/) or [Nuxt Auth Template](https://github.com/nuxt/examples/tree/main/examples/auth/local)
 
 ## Getting Started
 


### PR DESCRIPTION
The current link to "Nuxt Auth Template" in https://auth.nuxtjs.org homepage does not exist and results in a 404 page. There has been a directory restructure and the examples in the nuxt examples repo have been moved to the `examples` folder.