### PR TITLE
feat: add Asgardeo authentication provider

### DIFF
--- a/docs/content/en/providers/asgardeo.md
+++ b/docs/content/en/providers/asgardeo.md
@@ -1,0 +1,69 @@
+---
+title: Asgardeo
+description: Asgardeo is an identity-as-a-service platform by WSO2 built on OpenID Connect.
+position: 32
+category: Providers
+---
+
+[Source Code](https://github.com/nuxt-community/auth-module/blob/dev/src/providers/asgardeo.ts)
+
+[Asgardeo](https://wso2.com/asgardeo/) is an identity-as-a-service (IDaaS) platform by WSO2 with first-class OpenID Connect support.
+
+## Usage
+
+```js
+auth: {
+  strategies: {
+    asgardeo: {
+      clientId: '<CLIENT_ID>',
+      issuer: 'https://api.asgardeo.io/t/<TENANT>',
+      scope: ['openid', 'profile', 'email']
+    }
+  }
+}
+```
+
+Anywhere in your application logic:
+
+```js
+this.$auth.loginWith('asgardeo')
+```
+
+💁 This provider is based on the [openIDConnect scheme](../schemes/openIDConnect) and supports all of its options.
+
+## Obtaining `clientId` and `issuer`
+
+`clientId` and `issuer` are **REQUIRED**.
+
+- `clientId` — register a **Single-Page Application** in the [Asgardeo Console](https://console.asgardeo.io) and copy its client ID. Public clients use the Authorization Code flow with PKCE, so no client secret is stored in the bundle.
+- `issuer` — your Asgardeo organization URL, `https://api.asgardeo.io/t/<TENANT>`, where `<TENANT>` is your organization name. The provider uses this value to resolve the Asgardeo OpenID Connect discovery endpoint automatically.
+
+The provider derives the OpenID Connect discovery document from the issuer:
+
+```
+<issuer>/oauth2/token/.well-known/openid-configuration
+```
+
+All endpoints (authorization, token, userInfo, logout) are then resolved automatically from that document, so you normally do not set them by hand.
+
+## Redirect URLs
+
+In the Asgardeo Console, add your callback route to the application's **Authorized redirect URLs** (defaults to `/login`, e.g. `http://localhost:3000/login`). To be redirected back after logout, also add your logout target and set `logoutRedirectUri`:
+
+```js
+auth: {
+  strategies: {
+    asgardeo: {
+      clientId: '<CLIENT_ID>',
+      issuer: 'https://api.asgardeo.io/t/<TENANT>',
+      logoutRedirectUri: 'http://localhost:3000'
+    }
+  }
+}
+```
+
+Then log out with:
+
+```js
+await this.$auth.logout()
+```

--- a/src/providers/asgardeo.ts
+++ b/src/providers/asgardeo.ts
@@ -1,0 +1,25 @@
+import type { ProviderOptions, ProviderPartialOptions } from '../types'
+import type { OpenIDConnectSchemeOptions } from '../schemes'
+import { assignDefaults } from '../utils/provider'
+
+export interface AsgardeoProviderOptions
+  extends ProviderOptions,
+    OpenIDConnectSchemeOptions {
+  issuer: string
+}
+
+export function asgardeo(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
+  _nuxt: any,
+  strategy: ProviderPartialOptions<AsgardeoProviderOptions>
+): void {
+  const DEFAULTS: typeof strategy = {
+    scheme: 'openIDConnect',
+    endpoints: {
+      configuration: `${strategy.issuer}/oauth2/token/.well-known/openid-configuration`
+    },
+    scope: ['openid', 'profile', 'email']
+  }
+
+  assignDefaults(strategy, DEFAULTS)
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,3 +1,4 @@
+export * from './asgardeo'
 export * from './auth0'
 export * from './discord'
 export * from './facebook'

--- a/test/asgardeo.test.ts
+++ b/test/asgardeo.test.ts
@@ -1,0 +1,57 @@
+import { asgardeo, AsgardeoProviderOptions } from '../src/providers/asgardeo'
+import type { ProviderPartialOptions } from '../src/types'
+
+const ISSUER = 'https://api.asgardeo.io/t/example'
+
+const buildStrategy = (
+  overrides: Partial<ProviderPartialOptions<AsgardeoProviderOptions>> = {}
+): ProviderPartialOptions<AsgardeoProviderOptions> =>
+  ({
+    clientId: 'test_client_id',
+    issuer: ISSUER,
+    ...overrides
+  } as ProviderPartialOptions<AsgardeoProviderOptions>)
+
+describe('asgardeo provider', () => {
+  test('defaults to the openIDConnect scheme', () => {
+    const strategy = buildStrategy()
+    asgardeo({}, strategy)
+    expect(strategy.scheme).toBe('openIDConnect')
+  })
+
+  test('derives the discovery document endpoint from the issuer', () => {
+    const strategy = buildStrategy()
+    asgardeo({}, strategy)
+    expect(strategy.endpoints.configuration).toBe(
+      `${ISSUER}/oauth2/token/.well-known/openid-configuration`
+    )
+  })
+
+  test('applies the default OpenID Connect scope', () => {
+    const strategy = buildStrategy()
+    asgardeo({}, strategy)
+    expect(strategy.scope).toEqual(['openid', 'profile', 'email'])
+  })
+
+  test('merges a user-provided scope with default scope', () => {
+    const strategy = buildStrategy({ scope: ['openid', 'internal_login'] })
+    asgardeo({}, strategy)
+
+    expect(strategy.scope).toEqual([
+      'openid',
+      'profile',
+      'email',
+      'openid',
+      'internal_login'
+    ])
+  })
+
+  test('does not override a user-provided configuration endpoint', () => {
+    const custom = 'https://example.com/custom/.well-known/openid-configuration'
+    const strategy = buildStrategy({
+      endpoints: { configuration: custom }
+    })
+    asgardeo({}, strategy)
+    expect(strategy.endpoints.configuration).toBe(custom)
+  })
+})


### PR DESCRIPTION
## What does this PR do?

This PR adds an official Asgardeo authentication provider to `@nuxtjs/auth`. The new provider uses the existing OpenID Connect scheme and automatically derives the Asgardeo OIDC discovery endpoint from the configured issuer, allowing Nuxt developers to integrate Asgardeo authentication with minimal configuration instead of manually setting OIDC endpoints.

## Why was this PR needed?

This PR addresses issue #364. Currently, Asgardeo users must configure a generic OpenID Connect strategy manually, including discovery endpoints, token handling, and authentication settings. Investigation showed that the existing OpenID Connect scheme already supports the required authentication flow, including authorization code flow, PKCE, token handling, user information retrieval, and logout through discovery. 

This implementation adds a dedicated provider that follows the same architecture as existing providers, such as Auth0, while reusing the existing OpenID Connect functionality. Developers only need to provide the Asgardeo `clientId` and `issuer`, and the provider handles the remaining configuration automatically.

## What are the relevant issue numbers?

Closes #364

## Does this PR meet the acceptance criteria?

- [x] Tests added for new/changed behavior
- [x] All tests passing
- [x] Follows project style guide
- [x] No breaking changes introduced
- [x] Documentation updated (if applicable)